### PR TITLE
call grid.newpage() before assembling gtable

### DIFF
--- a/R/plot_assemble.R
+++ b/R/plot_assemble.R
@@ -2,9 +2,11 @@
 #' @importFrom grid grid.newpage grid.draw seekViewport pushViewport upViewport
 #' @export
 print.ggassemble <- function(x, newpage = is.null(vp), vp = NULL, ...) {
+  if (newpage) grid.newpage()
+
   assemble <- get_assemble(x)
   gtable <- assemble_grob(assemble)
-  if (newpage) grid.newpage()
+
   if (is.null(vp)) {
     grid.draw(gtable)
   } else {


### PR DESCRIPTION
Resolves #9. We need to create the new grid page before constructing the grob; otherwise RStudio detects the grid newpage + grob construction as two separate graphics events and draws an empty page for the initial plot.

This is consistent with how `ggplot2:::print.ggplot()` works, e.g.

```
> ggplot2:::print.ggplot
function(x, newpage = is.null(vp), vp = NULL, ...) {
  set_last_plot(x)
  if (newpage) grid.newpage()

  # Record dependency on 'ggplot2' on the display list
  # (AFTER grid.newpage())
  grDevices::recordGraphics(
    requireNamespace("ggplot2", quietly = TRUE),
    list(),
    getNamespace("ggplot2")
  )

  data <- ggplot_build(x)

  gtable <- ggplot_gtable(data)
  if (is.null(vp)) {
    grid.draw(gtable)
  } else {
    if (is.character(vp)) seekViewport(vp) else pushViewport(vp)
    grid.draw(gtable)
    upViewport()
  }

  invisible(x)
}
```

Note that the `gtable` is built after setting up a new page for the graphics device.