### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ p1 + plot_spacer() + p2
 You can make nested plots layout by wrapping part of the plots in parentheses - in these cases the layout is scoped to the different nesting levels
 
 ``` r
-p3 <- ggplot(mtcars) + geom_smooth(aes(disp, qsec))
+p3 <- ggplot(mtcars) + geom_smooth(aes(disp, qsec), method = "loess")
 p4 <- ggplot(mtcars) + geom_bar(aes(carb))
 
 p4 + {


### PR DESCRIPTION
Dear Thomas,
Good day.
Thank you for this nice alternative to `gidExtra`, `cowplot` packages. 
In the `README.md` file, on line number 67, the code snippet `p3 <- ggplot(mtcars) + geom_smooth(aes(disp, qsec))`, I'm unsure if its by design. Assuming its not by design, I have added `method = "loess"`. Without, `method="loess, executing p1 + p2 + p3 + plot_layout(ncol = 1)` is giving a warning, `geom_smooth() using method = 'loess' and formula 'y ~ x`

```
> sessionInfo()
R version 3.5.1 (2018-07-02)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 7 x64 (build 7601) Service Pack 1

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.1252 
[2] LC_CTYPE=English_United States.1252   
[3] LC_MONETARY=English_United States.1252
[4] LC_NUMERIC=C                          
[5] LC_TIME=English_United States.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets 
[6] methods   base     

other attached packages:
[1] ggplot2_3.0.0   patchwork_0.0.1

loaded via a namespace (and not attached):
 [1] Rcpp_0.12.18     rstudioapi_0.7   magrittr_1.5    
 [4] bindr_0.1.1      devtools_1.13.6  tidyselect_0.2.4
 [7] munsell_0.5.0    colorspace_1.3-2 R6_2.2.2        
[10] rlang_0.2.1      httr_1.3.1       plyr_1.8.4      
[13] dplyr_0.7.6      tools_3.5.1      grid_3.5.1      
[16] gtable_0.2.0     git2r_0.23.0     withr_2.1.2     
[19] yaml_2.2.0       lazyeval_0.2.1   digest_0.6.15   
[22] assertthat_0.2.0 tibble_1.4.2     crayon_1.3.4    
[25] bindrcpp_0.2.2   purrr_0.2.5      curl_3.2        
[28] glue_1.3.0       memoise_1.1.0    labeling_0.3    
[31] compiler_3.5.1   pillar_1.3.0     scales_0.5.0    
[34] pkgconfig_2.0.1 
```