### PR TITLE
don't increment tag index for guide_area

### DIFF
--- a/R/add_plot.R
+++ b/R/add_plot.R
@@ -68,4 +68,4 @@ plot_filler <- function() {
   p
 }
 is_empty <- function(x) inherits(x, 'plot_filler')
-
+has_tag.plot_filler <- function(x) FALSE

--- a/R/guide_area.R
+++ b/R/guide_area.R
@@ -18,4 +18,4 @@ patchGrob.guide_area <- function(x, guides = 'auto') {
   table <- NextMethod()
   gtable_add_grob(table, zeroGrob(), PANEL_ROW, PANEL_COL, name = 'panel-guide_area')
 }
-is_guide_area <- function(x) inherits(x, 'guide_area')
+has_tag.guide_area <- function(x) FALSE

--- a/R/guide_area.R
+++ b/R/guide_area.R
@@ -18,3 +18,4 @@ patchGrob.guide_area <- function(x, guides = 'auto') {
   table <- NextMethod()
   gtable_add_grob(table, zeroGrob(), PANEL_ROW, PANEL_COL, name = 'panel-guide_area')
 }
+is_guide_area <- function(x) inherits(x, 'guide_area')

--- a/R/patch.R
+++ b/R/patch.R
@@ -75,3 +75,5 @@ print.patch <- function(x, newpage = is.null(vp), vp = NULL, ...) {
 }
 #' @export
 plot.patch <- print.patch
+
+has_tag.ggplot <- function(x) !is_empty(x)

--- a/R/plot_annotation.R
+++ b/R/plot_annotation.R
@@ -86,15 +86,15 @@ recurse_tags <- function(x, levels, prefix, suffix, sep, offset = 1) {
       }
     } else {
       patches[[i]] <- patches[[i]] + labs(tag = paste0(prefix, level[tag_ind], suffix))
-      if ((is.ggplot(patches[[i]]) && !is_empty(patches[[i]])) ||
-          (is_wrapped_patch(patches[[i]]) && !attr(patches[[i]], 'settings')$ignore_tag)) {
+      if (!is_guide_area(patches[[i]]) && ((is.ggplot(patches[[i]]) && !is_empty(patches[[i]])) ||
+          (is_wrapped_patch(patches[[i]]) && !attr(patches[[i]], 'settings')$ignore_tag))) {
         tag_ind <- tag_ind + 1
       }
     }
   }
   x$patches$plots <- patches
   x <- x + labs(tag = paste0(prefix, level[tag_ind], suffix))
-  if ((is.ggplot(x) && !is_empty(x)) || (is_wrapped_patch(x) && !attr(x, 'settings')$ignore_tag)) {
+  if (!is_guide_area(x) && ((is.ggplot(x) && !is_empty(x)) || (is_wrapped_patch(x) && !attr(x, 'settings')$ignore_tag))) {
     tag_ind <- tag_ind + 1
   }
   list(

--- a/R/plot_annotation.R
+++ b/R/plot_annotation.R
@@ -1,3 +1,7 @@
+has_tag <- function(x) {
+    UseMethod('has_tag')
+}
+
 #' Annotate the final patchwork
 #'
 #' The result of this function can be added to a patchwork using `+` in the same
@@ -86,15 +90,14 @@ recurse_tags <- function(x, levels, prefix, suffix, sep, offset = 1) {
       }
     } else {
       patches[[i]] <- patches[[i]] + labs(tag = paste0(prefix, level[tag_ind], suffix))
-      if (!is_guide_area(patches[[i]]) && ((is.ggplot(patches[[i]]) && !is_empty(patches[[i]])) ||
-          (is_wrapped_patch(patches[[i]]) && !attr(patches[[i]], 'settings')$ignore_tag))) {
+      if (has_tag(patches[[i]])) {
         tag_ind <- tag_ind + 1
       }
     }
   }
   x$patches$plots <- patches
   x <- x + labs(tag = paste0(prefix, level[tag_ind], suffix))
-  if (!is_guide_area(x) && ((is.ggplot(x) && !is_empty(x)) || (is_wrapped_patch(x) && !attr(x, 'settings')$ignore_tag))) {
+  if (has_tag(x)) {
     tag_ind <- tag_ind + 1
   }
   list(

--- a/R/plot_spacer.R
+++ b/R/plot_spacer.R
@@ -30,3 +30,4 @@ plot_spacer <- function() {
   table
 }
 is_spacer <- function(x) inherits(x, 'spacer')
+has_tag.spacer <- function(x) FALSE

--- a/R/wrap_elements.R
+++ b/R/wrap_elements.R
@@ -141,3 +141,4 @@ offscreen_dev <- function() {
   }
 }
 
+has_tag.wrapped_patch <- function(x) !attr(x, 'settings')$ignore_tag


### PR DESCRIPTION
Tags for guide_areas are never plotted, which makes sense, at legends typically do not receive an extra panel. However, the tag index is still incremented, resulting in a discontinuity for the next plot. This patch fixes this issue.