### PR TITLE
fix legend justification for fixed aspect ratio plots

### DIFF
--- a/R/plot_patchwork.R
+++ b/R/plot_patchwork.R
@@ -392,32 +392,56 @@ simplify_fixed <- function(gt, gt_new, panels, rows, cols) {
   for (i in seq_len(left - 1)) {
     table <- gt[p_rows, i]
     if (length(table$grobs) != 0) {
-      grobname <- paste(table$layout$name, collapse = ', ')
-      gt_new <- gtable_add_grob(gt_new, table, rows[1], i, clip = 'off', name = grobname, z = max(table$layout$z))
+      if (length(table$grobs) == 1) {
+        grobname <- table$layout$name
+        grob <- table$grobs[[1]]
+      } else {
+        grobname <- paste(table$layout$name, collapse = ', ')
+        grob <- table
+      }
+      gt_new <- gtable_add_grob(gt_new, grob, rows[1], i, clip = 'off', name = grobname, z = max(table$layout$z))
     }
   }
   right <- if (length(right) != 0) max(right) else cols[2]
   for (i in seq_len(ncol(gt) - right)) {
     table <- gt[p_rows, i + right]
     if (length(table$grobs) != 0) {
-      grobname <- paste(table$layout$name, collapse = ', ')
-      gt_new <- gtable_add_grob(gt_new, table, rows[1], i + cols[1] + right - cols[2], clip = 'off', name = grobname, z = max(table$layout$z))
+      if (length(table$grobs) == 1) {
+        grobname <- table$layout$name
+        grob <- table$grobs[[1]]
+      } else {
+        grobname <- paste(table$layout$name, collapse = ', ')
+        grob <- table
+      }
+      gt_new <- gtable_add_grob(gt_new, grob, rows[1], i + cols[1] + right - cols[2], clip = 'off', name = grobname, z = max(table$layout$z))
     }
   }
   top <- if (length(top) != 0) min(top) else rows[1]
   for (i in seq_len(top - 1)) {
     table <- gt[i, p_cols]
     if (length(table$grobs) != 0) {
-      grobname <- paste(table$layout$name, collapse = ', ')
-      gt_new <- gtable_add_grob(gt_new, table, i, cols[1], clip = 'off', name = grobname, z = max(table$layout$z))
+      if (length(table$grobs) == 1) {
+        grobname <- table$layout$name
+        grob <- table$grobs[[1]]
+      } else {
+        grobname <- paste(table$layout$name, collapse = ', ')
+        grob <- table
+      }
+      gt_new <- gtable_add_grob(gt_new, grob, i, cols[1], clip = 'off', name = grobname, z = max(table$layout$z))
     }
   }
   bottom <- if (length(bottom) != 0) max(bottom) else rows[2]
   for (i in seq_len(nrow(gt) - bottom)) {
     table <- gt[i + bottom, p_cols]
     if (length(table$grobs) != 0) {
-      grobname <- paste(table$layout$name, collapse = ', ')
-      gt_new <- gtable_add_grob(gt_new, table, i + rows[1] + bottom - rows[2], cols[1], clip = 'off', name = grobname, z = max(table$layout$z))
+      if (length(table$grobs) == 1) {
+        grobname <- table$layout$name
+        grob <- table$grobs[[1]]
+      } else {
+        grobname <- paste(table$layout$name, collapse = ', ')
+        grob <- table
+      }
+      gt_new <- gtable_add_grob(gt_new, grob, i + rows[1] + bottom - rows[2], cols[1], clip = 'off', name = grobname, z = max(table$layout$z))
     }
   }
   panel_name <- paste0('panel; ', paste(panels$layout$name, collapse = ', '))

--- a/tests/figs/add-base-graphics-p1-plot-1-10-1-10.svg
+++ b/tests/figs/add-base-graphics-p1-plot-1-10-1-10.svg
@@ -118,8 +118,8 @@
   </clipPath>
 </defs>
 <defs>
-  <clipPath id='cpNDM1LjM4fDY4NC4xNXw0OTYuOTh8ODEuODk='>
-    <rect x='435.38' y='81.89' width='248.77' height='415.09' />
+  <clipPath id='cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE='>
+    <rect x='435.13' y='81.81' width='249.15' height='415.27' />
   </clipPath>
 </defs>
 <defs>
@@ -128,8 +128,8 @@
   </clipPath>
 </defs>
 <defs>
-  <clipPath id='cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk='>
-    <rect x='435.21' y='81.89' width='249.03' height='415.09' />
+  <clipPath id='cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE='>
+    <rect x='435.13' y='81.81' width='249.15' height='415.27' />
   </clipPath>
 </defs>
 <defs>
@@ -139,50 +139,50 @@
 </defs>
 <rect x='291.49' y='-114.17' width='507.64' height='821.62' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
 <defs>
-  <clipPath id='cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk='>
-    <rect x='435.21' y='81.89' width='249.03' height='415.09' />
+  <clipPath id='cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE='>
+    <rect x='435.13' y='81.81' width='249.15' height='415.27' />
   </clipPath>
 </defs>
-<circle cx='444.43' cy='481.61' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='470.05' cy='438.90' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='495.67' cy='396.20' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='521.29' cy='353.49' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='546.91' cy='310.79' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='572.54' cy='268.08' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='598.16' cy='225.38' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='623.78' cy='182.67' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='649.40' cy='139.97' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
-<circle cx='675.02' cy='97.27' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjIxfDY4NC4yNHw0OTYuOTh8ODEuODk=)' />
+<circle cx='444.36' cy='481.70' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='469.99' cy='438.98' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='495.63' cy='396.25' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='521.26' cy='353.53' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='546.89' cy='310.81' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='572.52' cy='268.08' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='598.16' cy='225.36' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='623.79' cy='182.64' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='649.42' cy='139.91' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
+<circle cx='675.05' cy='97.19' r='2.70pt' style='stroke-width: 0.75;' clip-path='url(#cpNDM1LjEzfDY4NC4yOHw0OTcuMDh8ODEuODE=)' />
 <defs>
   <clipPath id='cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc='>
     <rect x='376.09' y='22.77' width='338.43' height='547.75' />
   </clipPath>
 </defs>
-<line x1='470.05' y1='496.98' x2='675.02' y2='496.98' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='470.05' y1='496.98' x2='470.05' y2='504.18' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='521.29' y1='496.98' x2='521.29' y2='504.18' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='572.54' y1='496.98' x2='572.54' y2='504.18' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='623.78' y1='496.98' x2='623.78' y2='504.18' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='675.02' y1='496.98' x2='675.02' y2='504.18' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='466.72' y='522.90' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='517.96' y='522.90' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='569.20' y='522.90' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='620.44' y='522.90' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='668.35' y='522.90' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text></g>
-<line x1='435.21' y1='438.90' x2='435.21' y2='97.27' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='435.21' y1='438.90' x2='428.01' y2='438.90' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='435.21' y1='353.49' x2='428.01' y2='353.49' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='435.21' y1='268.08' x2='428.01' y2='268.08' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='435.21' y1='182.67' x2='428.01' y2='182.67' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<line x1='435.21' y1='97.27' x2='428.01' y2='97.27' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.93,442.24) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.93,356.83) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.93,271.42) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.93,186.01) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.93,103.94) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text></g>
-<polyline points='435.21,496.98 684.24,496.98 684.24,81.89 435.21,81.89 435.21,496.98 ' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='548.05' y='551.70' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='23.34px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
-<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(389.13,301.11) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='23.34px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
+<line x1='469.99' y1='497.08' x2='675.05' y2='497.08' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='469.99' y1='497.08' x2='469.99' y2='504.28' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='521.26' y1='497.08' x2='521.26' y2='504.28' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='572.52' y1='497.08' x2='572.52' y2='504.28' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='623.79' y1='497.08' x2='623.79' y2='504.28' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='675.05' y1='497.08' x2='675.05' y2='504.28' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='466.66' y='523.00' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='517.92' y='523.00' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='569.19' y='523.00' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='620.45' y='523.00' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='668.38' y='523.00' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<line x1='435.13' y1='438.98' x2='435.13' y2='97.19' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='435.13' y1='438.98' x2='427.93' y2='438.98' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='435.13' y1='353.53' x2='427.93' y2='353.53' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='435.13' y1='268.08' x2='427.93' y2='268.08' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='435.13' y1='182.64' x2='427.93' y2='182.64' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<line x1='435.13' y1='97.19' x2='427.93' y2='97.19' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.85,442.31) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.85,356.87) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.85,271.42) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.85,185.97) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>8</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(417.85,103.86) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='13.34px' lengthAdjust='spacingAndGlyphs'>10</text></g>
+<polyline points='435.13,497.08 684.28,497.08 684.28,81.81 435.13,81.81 435.13,497.08 ' style='stroke-width: 0.75;' clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)' />
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text x='548.04' y='551.80' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='23.34px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
+<g clip-path='url(#cpMzc2LjA5fDcxNC41Mnw1NzAuNTJ8MjIuNzc=)'><text transform='translate(389.05,301.12) rotate(-90)' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='23.34px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/far-legend-justification.svg
+++ b/tests/figs/far-legend-justification.svg
@@ -1,0 +1,193 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMTM3LjcwfDU4Mi4zMHw1NzYuMDB8MC4wMA=='>
+    <rect x='137.70' y='0.00' width='444.60' height='576.00' />
+  </clipPath>
+</defs>
+<rect x='137.70' y='0.00' width='444.60' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' clip-path='url(#cpMTM3LjcwfDU4Mi4zMHw1NzYuMDB8MC4wMA==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTQzLjE4fDU3Ni44MnwyOTYuNjV8MjIuNzc='>
+    <rect x='143.18' y='22.77' width='433.65' height='273.87' />
+  </clipPath>
+</defs>
+<rect x='143.18' y='22.77' width='433.65' height='273.87' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' clip-path='url(#cpMTQzLjE4fDU3Ni44MnwyOTYuNjV8MjIuNzc=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU='>
+    <rect x='175.95' y='28.25' width='237.53' height='237.53' />
+  </clipPath>
+</defs>
+<rect x='175.95' y='28.25' width='237.53' height='237.53' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='294.72' cy='204.60' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='294.72' cy='190.20' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='149.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='294.72' cy='127.99' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='190.20' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='294.72' cy='107.94' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='220.53' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='113.60' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='39.05' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='294.72' cy='157.30' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='294.72' cy='141.87' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='180.43' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='175.29' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='165.01' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='165.52' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='169.64' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='179.92' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='127.22' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='151.64' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='116.17' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='113.34' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='183.00' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='231.59' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='189.43' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='141.87' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='198.43' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='193.28' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='254.98' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='294.72' cy='229.27' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='402.68' cy='252.41' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<circle cx='186.75' cy='149.58' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<rect x='175.95' y='28.25' width='237.53' height='237.53' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHwyNjUuNzh8MjguMjU=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='219.44' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>16</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='168.03' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>18</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='116.62' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='65.21' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>22</text></g>
+<polyline points='173.21,216.42 175.95,216.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.21,165.01 175.95,165.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.21,113.60 175.95,113.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.21,62.18 175.95,62.18 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(156.22,158.64) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='23.25px' lengthAdjust='spacingAndGlyphs'>qsec</text></g>
+<polyline points='186.75,268.52 186.75,265.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='240.73,268.52 240.73,265.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='294.72,268.52 294.72,265.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='348.70,268.52 348.70,265.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='402.68,268.52 402.68,265.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='184.30' y='276.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='238.29' y='276.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='292.27' y='276.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='346.25' y='276.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='400.24' y='276.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='288.00' y='288.89' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='13.44px' lengthAdjust='spacingAndGlyphs'>cyl</text></g>
+<rect x='424.44' y='122.07' width='60.53' height='49.88' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='424.44' y='130.78' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='60.53px' lengthAdjust='spacingAndGlyphs'>as.factor(vs)</text></g>
+<rect x='424.44' y='137.40' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='433.08' cy='146.04' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='424.44' y='154.68' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='433.08' cy='163.32' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='447.20' y='149.06' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='447.20' y='166.34' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMTQzLjE4fDU3Ni44Mnw1NzAuNTJ8Mjk2LjY1'>
+    <rect x='143.18' y='296.65' width='433.65' height='273.87' />
+  </clipPath>
+</defs>
+<rect x='143.18' y='296.65' width='433.65' height='273.87' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' clip-path='url(#cpMTQzLjE4fDU3Ni44Mnw1NzAuNTJ8Mjk2LjY1)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz'>
+    <rect x='175.95' y='302.13' width='237.53' height='237.53' />
+  </clipPath>
+</defs>
+<rect x='175.95' y='302.13' width='237.53' height='237.53' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='294.72' cy='478.47' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='294.72' cy='464.07' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='423.20' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='294.72' cy='401.87' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='464.07' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='294.72' cy='381.81' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='494.41' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='387.47' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='312.92' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='294.72' cy='431.17' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='294.72' cy='415.75' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='454.31' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='449.17' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='438.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='439.40' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='443.51' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='453.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='401.09' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='425.52' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='390.04' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='387.21' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='467.93' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='456.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='505.46' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='463.30' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='415.75' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='472.30' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='467.16' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='528.85' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='294.72' cy='503.15' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='402.68' cy='526.28' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<circle cx='186.75' cy='423.46' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<rect x='175.95' y='302.13' width='237.53' height='237.53' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMTc1Ljk1fDQxMy40OHw1MzkuNjV8MzAyLjEz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='493.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>16</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='441.91' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>18</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='390.49' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>20</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='161.24' y='339.08' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='9.78px' lengthAdjust='spacingAndGlyphs'>22</text></g>
+<polyline points='173.21,490.30 175.95,490.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.21,438.88 175.95,438.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.21,387.47 175.95,387.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.21,336.06 175.95,336.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(156.22,432.51) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='23.25px' lengthAdjust='spacingAndGlyphs'>qsec</text></g>
+<polyline points='186.75,542.39 186.75,539.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='240.73,542.39 240.73,539.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='294.72,542.39 294.72,539.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='348.70,542.39 348.70,539.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='402.68,542.39 402.68,539.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='184.30' y='550.63' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='238.29' y='550.63' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='292.27' y='550.63' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='346.25' y='550.63' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='400.24' y='550.63' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='288.00' y='562.76' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='13.44px' lengthAdjust='spacingAndGlyphs'>cyl</text></g>
+<rect x='424.44' y='395.95' width='146.91' height='49.88' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='424.44' y='404.65' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='146.91px' lengthAdjust='spacingAndGlyphs'>a very looooooong legend title</text></g>
+<rect x='424.44' y='411.27' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='433.08' cy='419.91' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='424.44' y='428.55' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='433.08' cy='437.19' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='447.20' y='422.93' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='447.20' y='440.21' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='148.66' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='137.77px' lengthAdjust='spacingAndGlyphs'>FAR legend justification</text></g>
+</svg>

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -45,4 +45,11 @@ test_that("Fixed aspect plots behave", {
   expect_doppelganger('FAR dimensions can be set with units:...', {
     p1 + p2 + p_f + plot_layout(widths = unit(c(1, 3, -1), c('null', 'cm', 'null')))
   })
+
+  p_l1 <- ggplot(mtcars, aes(cyl, qsec, color=as.factor(vs))) +
+    geom_point()
+  p_l2 <- p_l1 + labs(color="a very looooooong legend title")
+  expect_doppelganger('FAR legend justification', {
+    p_l1 + p_l2 + plot_layout(ncol=1) & theme(legend.justification = "left", aspect.ratio=1)
+  })
 })


### PR DESCRIPTION
On the current master branch, legend justification for fixed aspect ratio plots is broken:
``` r
library(ggplot2)
library(patchwork)
p1 <- ggplot(mtcars, aes(cyl, qsec, color=as.factor(vs))) +
    geom_point()
p2 <- p1 + labs(color="a very looooooong legend title")
p1 + p2 + plot_layout(ncol=1) & theme(legend.justification = "left", aspect.ratio=1)
```

![](https://i.imgur.com/1ZHGVPb.png)

<sup>Created on 2019-12-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This patch fixes this issue:
``` r
library(ggplot2)
library(patchwork)
p1 <- ggplot(mtcars, aes(cyl, qsec, color=as.factor(vs))) +
    geom_point()
p2 <- p1 + labs(color="a very looooooong legend title")
p1 + p2 + plot_layout(ncol=1) & theme(legend.justification = "left", aspect.ratio=1)
```

![](https://i.imgur.com/VfcHVH3.png)

<sup>Created on 2019-12-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>