### PR TITLE
Fix a small example code typo in plot_annotation.Rd

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # patchwork (development version)
 
+* Renaming of `align_plots()` to `align_patches()` to avoid namespace clash
+  with cowplot (#130)
+* Renaming of `as_grob()` (unexported) to `as_patch()` to avoid potential 
+  future namespace clash with cowplot (#131)
+* Fix bug in plot simplification with `theme(strip.placement = 'outside')` 
+  (#132)
+
 # patchwork 1.0.0
 
 * First CRAN release. Provide utility and operators for assembling and nesting

--- a/R/plot_annotation.R
+++ b/R/plot_annotation.R
@@ -59,7 +59,7 @@ has_tag <- function(x) {
 #'   plot_annotation(tag_levels = 'A')
 #'
 #' # Add multilevel tagging to nested layouts
-#' p1 / (p2 | p3 + plot_layout(tag_level = 'new')) +
+#' p1 / ((p2 | p3) + plot_layout(tag_level = 'new')) +
 #'   plot_annotation(tag_levels = c('A', '1'))
 #'
 plot_annotation <- function(title = NULL, subtitle = NULL, caption = NULL,

--- a/R/plot_patchwork.R
+++ b/R/plot_patchwork.R
@@ -518,15 +518,27 @@ add_strips <- function(gt) {
   )
   if (!any(grepl('strip-b', gt$layout$name))) {
     gt <- gtable_add_rows(gt, unit(0, 'mm'), panel_loc$b + strip_pos)
+  } else if (strip_pos == 2) {
+    gt$heights[panel_loc$b + 1] <- sum(gt$heights[panel_loc$b + c(1, 2)])
+    gt <- gt[-(panel_loc$b + 2), ]
   }
   if (!any(grepl('strip-t', gt$layout$name))) {
     gt <- gtable_add_rows(gt, unit(0, 'mm'), panel_loc$t - 1 - strip_pos)
+  } else if (strip_pos == 2) {
+    gt$heights[panel_loc$t - 1] <- sum(gt$heights[panel_loc$t - c(1, 2)])
+    gt <- gt[-(panel_loc$t - 2), ]
   }
   if (!any(grepl('strip-r', gt$layout$name))) {
     gt <- gtable_add_cols(gt, unit(0, 'mm'), panel_loc$r + strip_pos)
+  } else if (strip_pos == 2) {
+    gt$widths[panel_loc$r + 1] <- sum(gt$widths[panel_loc$r + c(1, 2)])
+    gt <- gt[, -(panel_loc$r + 2)]
   }
   if (!any(grepl('strip-l', gt$layout$name))) {
     gt <- gtable_add_cols(gt, unit(0, 'mm'), panel_loc$l - 1 - strip_pos)
+  } else if (strip_pos == 2) {
+    gt$widths[panel_loc$l - 1] <- sum(gt$widths[panel_loc$l - c(1, 2)])
+    gt <- gt[-(panel_loc$l - 2), ]
   }
   gt
 }


### PR DESCRIPTION
I found a small code typo in plot_annotation.Rd 's example.

# Add multilevel tagging to nested layouts
`p1 / (p2 | p3 + plot_layout(tag_level = 'new')) +
  plot_annotation(tag_levels = c('A', '1'))`
It makes p2 and p3 two separate objects but not a patchwork object so the 
`+ plot_layout(tag_level = 'new')` 
only be set up to p3, which makes the final tag is **"A/B/C1"**.

I change the code to  
`p1 / ((p2 | p3) + plot_layout(tag_level = 'new')) +
  plot_annotation(tag_levels = c('A', '1'))` 
so the tag becomes to **"A/B1/B2"**, which I assume is the original purpose。