### PR TITLE
Arithmetic documentation change suggestions

### DIFF
--- a/R/arithmetic.R
+++ b/R/arithmetic.R
@@ -15,13 +15,13 @@
 #' Adding elements such as geoms to composed objects will add them to the final
 #' `ggplot` object in the composition.
 #'
-#' Often you are interested in creating single column or single row layouts.
+#' Often you are interested in creating single-column or single-row layouts.
 #' `patchwork` provides `|` (besides) and `/` (over) operators to support
-#' stacking and packing of plots. See the exampels for their use.
+#' stacking and packing of plots. See the examples for their use.
 #'
-#' In order to reduce code repetition `patchwork` provides two operators for
-#' adding ggplot elements (geoms, themes, facets, etc.) to multiple/all plots in
-#' a patchwork. `*` will add the element to all plots in the current nesting
+#' To reduce code repetition, `patchwork` provides two operators for adding
+#' ggplot elements (geoms, themes, facets, etc.) to multiple/all plots in a
+#' patchwork. `*` will add the element to all plots in the current nesting
 #' level, while `&` will recurse into nested patches.
 #'
 #' @param e1 A `ggplot` or `patchwork` object

--- a/R/arithmetic.R
+++ b/R/arithmetic.R
@@ -1,22 +1,19 @@
 #' Plot arithmetic
 #'
 #' In addition to the `+` operator known in `ggplot2`, `patchwork` defines logic
-#' for some of the other operators that aids in building up your plot
-#' composition and reduce code-reuse.
+#' for some of the other operators that aid in constructing plot composition and
+#' reduce code-reuse.
 #'
 #' @details
-#' `patchwork` augment the `+` operator from `ggplot2` and allows the user to
-#' add full `ggplot` objects together in order to compose them into the same
-#' view. The last added plot is always the active one where new geoms etc. are
-#' added to. Another operator that is much like it, but not quite, is `-`. It
-#' also adds plots together but instead of adding the right hand side to the
-#' patchwork defined in the left hand side, it puts the left hand side besides
-#' the right hand side in a patchwork. This might sound confusing, but in
-#' essence `-` ensures that the right and left side are put in the same nesting
-#' level (`+` puts the right side *into* the left side). Using `-` might seem
-#' unintuitive if you think of the operator as "subtrack", but look at it as a
-#' hyphen instead (the underlying reason is that `-` is the only operator in the
-#' same precedence group as `+`).
+#' `patchwork` augments the `+` operator from `ggplot2` and allows the user to
+#' add full `ggplot` objects together to compose them into the same view. The
+#' related `-` operator also adds plots together, but instead of adding the
+#' right-hand side to the patchwork defined in the left-hand side, it puts the
+#' left-hand side beside the right-hand side in a patchwork. The `-` should be
+#' more intuitively thought of "hyphen" rather than "subtract" (the technical
+#' reason is that `-` is the only operator in the same precedence group as `+`).
+#' Adding elements such as geoms to composed objects will add them to the final
+#' `ggplot` object in the composition.
 #'
 #' Often you are interested in creating single column or single row layouts.
 #' `patchwork` provides `|` (besides) and `/` (over) operators to support

--- a/man/plot_arithmetic.Rd
+++ b/man/plot_arithmetic.Rd
@@ -30,30 +30,27 @@ A \code{patchwork} object
 }
 \description{
 In addition to the \code{+} operator known in \code{ggplot2}, \code{patchwork} defines logic
-for some of the other operators that aids in building up your plot
-composition and reduce code-reuse.
+for some of the other operators that aid in constructing plot composition and
+reduce code-reuse.
 }
 \details{
-\code{patchwork} augment the \code{+} operator from \code{ggplot2} and allows the user to
-add full \code{ggplot} objects together in order to compose them into the same
-view. The last added plot is always the active one where new geoms etc. are
-added to. Another operator that is much like it, but not quite, is \code{-}. It
-also adds plots together but instead of adding the right hand side to the
-patchwork defined in the left hand side, it puts the left hand side besides
-the right hand side in a patchwork. This might sound confusing, but in
-essence \code{-} ensures that the right and left side are put in the same nesting
-level (\code{+} puts the right side \emph{into} the left side). Using \code{-} might seem
-unintuitive if you think of the operator as "subtrack", but look at it as a
-hyphen instead (the underlying reason is that \code{-} is the only operator in the
-same precedence group as \code{+}).
+\code{patchwork} augments the \code{+} operator from \code{ggplot2} and allows the user to
+add full \code{ggplot} objects together to compose them into the same view. The
+related \code{-} operator also adds plots together, but instead of adding the
+right-hand side to the patchwork defined in the left-hand side, it puts the
+left-hand side beside the right-hand side in a patchwork. The \code{-} should be
+more intuitively thought of "hyphen" rather than "subtract" (the technical
+reason is that \code{-} is the only operator in the same precedence group as \code{+}).
+Adding elements such as geoms to composed objects will add them to the final
+\code{ggplot} object in the composition.
 
-Often you are interested in creating single column or single row layouts.
+Often you are interested in creating single-column or single-row layouts.
 \code{patchwork} provides \code{|} (besides) and \code{/} (over) operators to support
-stacking and packing of plots. See the exampels for their use.
+stacking and packing of plots. See the examples for their use.
 
-In order to reduce code repetition \code{patchwork} provides two operators for
-adding ggplot elements (geoms, themes, facets, etc.) to multiple/all plots in
-a patchwork. \code{*} will add the element to all plots in the current nesting
+To reduce code repetition, \code{patchwork} provides two operators for adding
+ggplot elements (geoms, themes, facets, etc.) to multiple/all plots in a
+patchwork. \code{*} will add the element to all plots in the current nesting
 level, while \code{&} will recurse into nested patches.
 }
 \examples{


### PR DESCRIPTION
I've made some grammar and spelling corrections as well as sentence changes to the documentation for the arithmetic. Please consider the changes and alter to fit your desired wording.

I would also suggest maybe describing `-` as "add to negative position" or some other way to convey that the negative is on the left-hand side, hyphen doesn't really evoke that idea.