### PR TITLE
Automatically determine prefix and suffix from tags

### DIFF
--- a/R/plot_annotation.R
+++ b/R/plot_annotation.R
@@ -108,14 +108,14 @@ recurse_tags <- function(x, levels, prefix, suffix, sep, offset = 1) {
   }
 
   if (prefix == "" && nchar(levels > 1)) {
-    index <- find_index_substr(levels, level[1])
+    index <- find_index_substr(levels, as.character(level[1]))
     if (index > 1) {
       prefix <- substr(levels, 1, index - 1)
     }
   }
 
   if (suffix == "" && nchar(levels > 1)) {
-    index <- find_index_substr(levels, level[1])
+    index <- find_index_substr(levels, as.character(level[1]))
     suffix <- substr(levels, index + 1, nchar(levels))
   }
 
@@ -151,6 +151,22 @@ recurse_tags <- function(x, levels, prefix, suffix, sep, offset = 1) {
     patches = x,
     tag_ind = tag_ind
   )
+}
+find_index_substr <- function(string, substring) {
+  index <- 1
+  match <- FALSE
+  while (index <= nchar(string) && !match) {
+    if (substr(string, index, index) == substring) {
+      match <- TRUE
+    } else {
+      index <- index + 1
+    }
+  }
+  if (match) {
+    return(index)
+  } else {
+    return(NA)
+  }
 }
 #' @importFrom ggplot2 ggplot labs ggplotGrob
 #' @importFrom gtable gtable_add_rows gtable_add_cols
@@ -189,21 +205,4 @@ annotate_table <- function(table, annotation) {
   table <- gtable_add_grob(table, get_grob(p, 'background'), 1, 1, nrow(table), ncol(table),
                            z = -Inf, name = 'background')
   table
-}
-
-find_index_substr <- function(string, substring) {
-  index <- 1
-  match <- FALSE
-  while (index <= nchar(string) && !match) {
-    if (substr(string, index, index) == substring) {
-      match <- TRUE
-    } else {
-      index <- index + 1
-    }
-  }
-  if (match) {
-    return(index)
-  } else {
-    return(NA)
-  }
 }

--- a/R/plot_annotation.R
+++ b/R/plot_annotation.R
@@ -108,17 +108,15 @@ recurse_tags <- function(x, levels, prefix, suffix, sep, offset = 1) {
   }
 
   if (prefix == "" && nchar(levels > 1)) {
-    index <- gregexpr(pattern = as.character(levels), levels)[[1]][1]
+    index <- find_index_substr(levels, level[1])
     if (index > 1) {
       prefix <- substr(levels, 1, index - 1)
     }
   }
 
   if (suffix == "" && nchar(levels > 1)) {
-    index <- gregexpr(pattern = as.character(levels), levels)[[1]][1]
-    if (index > 1) {
-      suffix <- substr(levels, index + 1, nchar(levels))
-    }
+    index <- find_index_substr(levels, level[1])
+    suffix <- substr(levels, index + 1, nchar(levels))
   }
 
   patches <- x$patches$plots
@@ -191,4 +189,21 @@ annotate_table <- function(table, annotation) {
   table <- gtable_add_grob(table, get_grob(p, 'background'), 1, 1, nrow(table), ncol(table),
                            z = -Inf, name = 'background')
   table
+}
+
+find_index_substr <- function(string, substring) {
+  index <- 1
+  match <- FALSE
+  while (index <= nchar(string) && !match) {
+    if (substr(string, index, index) == substring) {
+      match <- TRUE
+    } else {
+      index <- index + 1
+    }
+  }
+  if (match) {
+    return(index)
+  } else {
+    return(NA)
+  }
 }

--- a/R/plot_annotation.R
+++ b/R/plot_annotation.R
@@ -91,15 +91,36 @@ ggplot_add.plot_annotation <- function(object, plot, object_name) {
 #' @importFrom utils as.roman
 recurse_tags <- function(x, levels, prefix, suffix, sep, offset = 1) {
   if (length(levels) == 0) return(list(patches = x, tab_ind = offset))
-  level <- switch(
-    as.character(levels[1]),
-    a = letters,
-    A = LETTERS,
-    "1" = 1:100,
-    i = tolower(as.roman(1:100)),
-    I = as.roman(1:100),
+
+  levels <- as.character(levels[1])
+  if (grepl("a", levels)) {
+    level <- letters
+  } else if (grepl("A", levels)) {
+    level <- LETTERS
+  } else if (grepl("1", levels)) {
+    level <- 1:100
+  } else if (grepl("i", levels)) {
+    level <- tolower(as.roman(1:100))
+  } else if (grepl("I", levels)) {
+    level <- as.roman(1:100)
+  } else {
     stop('Unknown tag type: ', levels[1], call. = FALSE)
-  )
+  }
+
+  if (prefix == "" && nchar(levels > 1)) {
+    index <- gregexpr(pattern = as.character(levels), levels)[[1]][1]
+    if (index > 1) {
+      prefix <- substr(levels, 1, index - 1)
+    }
+  }
+
+  if (suffix == "" && nchar(levels > 1)) {
+    index <- gregexpr(pattern = as.character(levels), levels)[[1]][1]
+    if (index > 1) {
+      suffix <- substr(levels, index + 1, nchar(levels))
+    }
+  }
+
   patches <- x$patches$plots
   tag_ind <- offset
   for (i in seq_along(patches)) {


### PR DESCRIPTION
I have implemented an automatic detection of the `tag_prefix` and `tag_suffix` from the `tag_levels` as described in #169. It works like this:

1. Look whether `tag_levels` contains one of the supported tags using `grepl()`
2. If it does and `tag_levels` is longer than 1 character then find the index of the supported tag inside `tag_levels`
3. Use anything that comes before this index as `tag_prefix`
4. Use anything that comes after this index as `tag_suffix`

Some examples:

- In the case of `tag_levels = "A"`, `tag_prefix` and `tag_suffix` are left blank.
- In case of `tag_levels = "[A"`, `tag_prefix` is set to `"]"` and `tag_suffix` is left blank.
- In case of `tag_levels = "A}"`, `tag_prefix` is left blank and `tag_suffix` is set to `"}"`.
- In case of `tag_levels = "(A)"`, `tag_prefix` is is set to `"("` and `tag_suffix` is set to `")"`.

Importantly, in the current implentation the automatic detection of the prefix is not "activated" when `tag_prefix` is set. The same is true for the suffix is `tag_suffix` is set.

```r
library(ggplot2)
p1 <- ggplot(mtcars, aes(mpg, hp)) + geom_point()
p2 <- ggplot(mtcars, aes(wt)) + geom_histogram()

p1 + p2 + plot_annotation(tag_levels = "1")
```
![image](https://user-images.githubusercontent.com/11788080/80756875-90f83500-8b33-11ea-8a92-6ddef4ad92bd.png)

```r
p1 + p2 + plot_annotation(tag_levels = "A)")
```
![image](https://user-images.githubusercontent.com/11788080/80756928-a1a8ab00-8b33-11ea-8a48-642068416f44.png)

```r
p1 + p2 + plot_annotation(tag_levels = "[I]")
```
![image](https://user-images.githubusercontent.com/11788080/80756989-bd13b600-8b33-11ea-9f22-a961c0df9c4d.png)

```r
p1 + p2 + plot_annotation(tag_levels = "{a")
```
![image](https://user-images.githubusercontent.com/11788080/80757081-e16f9280-8b33-11ea-8701-e545cb214007.png)

```r
p1 + p2 + plot_annotation(tag_levels = "(A)", tag_prefix = "[", tag_suffix = "]")
```
![image](https://user-images.githubusercontent.com/11788080/80757160-0106bb00-8b34-11ea-8b49-80f1092e4ad5.png)
