### PR TITLE
Fix pkgdown yml file

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,3 @@
-destination: docs
 url: https://patchwork.data-imaginist.com
 
 authors:


### PR DESCRIPTION
As you can see by looking at [the copy of this file on the gh-pages branch](https://github.com/thomasp85/patchwork/blob/gh-pages/pkgdown.yml), it's not taken into account, which means your blog posts are not linked and the vignettes are not updated correctly (last update 12 months ago).

I'm not 100% sure this will fix the issue but I think so.