### PR TITLE
Make plot method robust to grid Viewport errors

### DIFF
--- a/R/plot_patchwork.R
+++ b/R/plot_patchwork.R
@@ -28,7 +28,7 @@ print.patchwork <- function(x, newpage = is.null(vp), vp = NULL, ...) {
       if (Sys.getenv("RSTUDIO") == "1") {
         stop("The RStudio 'Plots' window is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
       } else {
-        stop("The Viewport is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
+        stop("The viewport is too small to show this patchwork.\n Please make it larger.", call. = FALSE)
       }
     }
   } else {
@@ -42,7 +42,7 @@ print.patchwork <- function(x, newpage = is.null(vp), vp = NULL, ...) {
       if (Sys.getenv("RSTUDIO") == "1") {
         stop("The RStudio 'Plots' window is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
       } else {
-        stop("The Viewport is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
+        stop("The viewport is too small to show this patchwork.\n Please make it larger.", call. = FALSE)
       }
     }
     upViewport()

--- a/R/plot_patchwork.R
+++ b/R/plot_patchwork.R
@@ -23,14 +23,28 @@ print.patchwork <- function(x, newpage = is.null(vp), vp = NULL, ...) {
   set_last_plot(x)
 
   if (is.null(vp)) {
-    grid.draw(gtable)
+    grid_drawn <- tryCatch(grid.draw(gtable), error = function(e) e)
+    if (inherits(grid_drawn, "simpleError")) {
+      if (Sys.getenv("RSTUDIO") == "1") {
+        stop("The RStudio 'Plots' window is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
+      } else {
+        stop("The Viewport is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
+      }
+    }
   } else {
     if (is.character(vp)) {
       seekViewport(vp)
     } else {
       pushViewport(vp)
     }
-    grid.draw(gtable)
+    grid_drawn <- tryCatch(grid.draw(gtable), error = function(e) e)
+    if (inherits(grid_drawn, "simpleError")) {
+      if (Sys.getenv("RSTUDIO") == "1") {
+        stop("The RStudio 'Plots' window is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
+      } else {
+        stop("The Viewport is too small to show this patchwork.\n Please make the window larger.", call. = FALSE)
+      }
+    }
     upViewport()
   }
   invisible(x)


### PR DESCRIPTION
A frequent error we see with [`performance::check_model()`](https://easystats.github.io/performance/#comprehensive-visualization-of-model-checks) is users having the RStudio Plots pane too small for the 3x2 patchwork. This produces an error when `grid::grid.draw()` is called. This PR uses `tryCatch()` to catch such errors and give a more helpful error message.

Reprex (make the RStudio Plots pane small):
```r
library(performance)
library(
m <- lm(mpg ~ disp + hp, data = mtcars)
check_model(m)
```

Before:
```
Error in grid.Call(C_convert, x, as.integer(whatfrom), as.integer(whatto),  : 
  Viewport has zero dimension(s)
```

After (in RStudio):
```
Error: The RStudio 'Plots' window is too small to show this patchwork.
Please make the window larger.
```

After (not in RStudio):
```
Error: The viewport is too small to show this patchwork.
Please make it larger.
```