### PR TITLE
Shared titles and axes in `wrap_plots()`

### DIFF
--- a/R/wrap_plots.R
+++ b/R/wrap_plots.R
@@ -46,7 +46,8 @@
 #'
 wrap_plots <- function(..., ncol = NULL, nrow = NULL, byrow = NULL,
                        widths = NULL, heights = NULL, guides = NULL,
-                       tag_level = NULL, design = NULL) {
+                       tag_level = NULL, design = NULL, axes = NULL,
+                       axis_titles = axes) {
   if (is_valid_plot(..1)) {
     plots <- list(...)
   } else if (is.list(..1)) {
@@ -68,7 +69,8 @@ wrap_plots <- function(..., ncol = NULL, nrow = NULL, byrow = NULL,
   }
   Reduce(`+`, plots, init = plot_filler()) + plot_layout(
     ncol = ncol, nrow = nrow, byrow = byrow, widths = widths, heights = heights,
-    guides = guides, tag_level = tag_level, design = design
+    guides = guides, tag_level = tag_level, design = design, axes = axes,
+    axis_titles = axis_titles
   )
 }
 

--- a/man/wrap_plots.Rd
+++ b/man/wrap_plots.Rd
@@ -13,7 +13,9 @@ wrap_plots(
   heights = NULL,
   guides = NULL,
   tag_level = NULL,
-  design = NULL
+  design = NULL,
+  axes = NULL,
+  axis_titles = axes
 )
 }
 \arguments{
@@ -47,6 +49,18 @@ auto-tagging should behave. See \code{\link[=plot_annotation]{plot_annotation()}
 \item{design}{Specification of the location of areas in the layout. Can either
 be specified as a text string or by concatenating calls to \code{\link[=area]{area()}} together.
 See the examples for further information on use.}
+
+\item{axes}{A string specifying how axes should be treated. \code{'keep'} will
+retain all axes in individual plots. \code{'collect'} will remove duplicated
+axes when placed in the same run of rows or columns of the layout.
+\code{'collect_x'} and \code{'collect_y'} will remove duplicated x-axes in the columns
+or duplicated y-axes in the rows respectively.}
+
+\item{axis_titles}{A string specifying how axis titltes should be treated.
+\code{'keep'} will retain all axis titles in individual plots. \code{'collect'} will
+remove duplicated titles in one direction and merge titles in the opposite
+direction. \code{'collect_x'} and \code{'collect_y'} control this for x-axis titles
+and y-axis titles respectively.}
 }
 \value{
 A \code{patchwork} object


### PR DESCRIPTION
This PR extends #337 with support for `wrap_plots()`. Currently `axes` and `axis_titles` are simply swallowed by `...` without a warning.