### PR TITLE
Merge titles more aggressively

### DIFF
--- a/R/collect_axes.R
+++ b/R/collect_axes.R
@@ -251,16 +251,15 @@ grob_id <- function(grobs, layout, byrow, merge = FALSE) {
   hash <- vapply(grobs[idx], function(x) hash(unname_grob(x)), character(1))
 
   # For multi-cell grobs, compute an extra identifier
-  index <- if (byrow) col(layout) else row(layout)
-  min <- ave(index, layout, FUN = min)
-  max <- ave(index, layout, FUN = max)
-  identifier <- paste0(min, ";", max)
-  if (merge) {
-    identifier[min == max] <- ""
+  if (!merge) {
+    index <- if (byrow) col(layout) else row(layout)
+    min <- ave(index, layout, FUN = min)
+    max <- ave(index, layout, FUN = max)
+    identifier <- paste0(min, ";", max)
+    # Include the multi-cell identifier in the hash
+    hash <- paste0(hash, identifier[valid])
   }
 
-  # Include the multi-cell identifier in the hash
-  hash <- paste0(hash, identifier[valid])
   layout[valid] <- match(hash, unique(hash))
   layout
 }

--- a/tests/testthat/_snaps/collect_axes/multi-cell-title-and-axis-collection.svg
+++ b/tests/testthat/_snaps/collect_axes/multi-cell-title-and-axis-collection.svg
@@ -30,55 +30,55 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjAuMTd8MjIuNzh8MjgzLjk1'>
-    <rect x='5.48' y='22.78' width='154.69' height='261.16' />
+  <clipPath id='cpNS40OHwxNjUuMjF8MjIuNzh8MjgzLjk1'>
+    <rect x='5.48' y='22.78' width='159.73' height='261.16' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjAuMTd8MjIuNzh8MjgzLjk1)'>
-<rect x='5.48' y='22.78' width='154.69' height='261.16' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpNS40OHwxNjUuMjF8MjIuNzh8MjgzLjk1)'>
+<rect x='5.48' y='22.78' width='159.73' height='261.16' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDMuMTd8MTU0LjY5fDQ1LjU3fDI3OC40Nw=='>
-    <rect x='43.17' y='45.57' width='111.52' height='232.90' />
+  <clipPath id='cpNDMuMTd8MTU5LjczfDQ1LjU3fDI3OC40Nw=='>
+    <rect x='43.17' y='45.57' width='116.56' height='232.90' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuMTd8MTU0LjY5fDQ1LjU3fDI3OC40Nw==)'>
-<rect x='43.17' y='45.57' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='93.97' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='93.97' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='101.73' cy='248.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='95.69' cy='169.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='84.05' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='81.46' cy='186.60' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='65.06' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='108.64' cy='227.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='101.73' cy='231.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='86.20' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='80.16' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='74.12' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='78.01' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='68.95' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='48.24' cy='56.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='48.24' cy='62.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='66.79' cy='73.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='143.15' cy='263.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='134.52' cy='265.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='149.62' cy='267.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='96.13' cy='242.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='70.24' cy='137.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='68.95' cy='144.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='60.75' cy='120.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='86.20' cy='94.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='121.15' cy='263.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='115.54' cy='241.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='134.52' cy='255.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='71.53' cy='120.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='88.36' cy='228.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='68.08' cy='146.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='95.69' cy='241.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='43.17' y='45.57' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNDMuMTd8MTU5LjczfDQ1LjU3fDI3OC40Nw==)'>
+<rect x='43.17' y='45.57' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='96.26' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='96.26' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='104.38' cy='248.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='98.07' cy='169.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='85.89' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='83.19' cy='186.60' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='66.05' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='111.59' cy='227.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='104.38' cy='231.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='88.15' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='81.83' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='75.52' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='79.58' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='70.11' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='48.47' cy='56.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='48.47' cy='62.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='67.86' cy='73.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='147.67' cy='263.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.65' cy='265.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='154.43' cy='267.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='98.52' cy='242.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='71.46' cy='137.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='70.11' cy='144.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='61.54' cy='120.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='88.15' cy='94.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='124.67' cy='263.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='118.81' cy='241.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.65' cy='255.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='72.82' cy='120.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='90.40' cy='228.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='69.21' cy='146.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='98.07' cy='241.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='43.17' y='45.57' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='38.24' y='255.65' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
@@ -92,311 +92,311 @@
 <text x='43.17' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
 </g>
 <defs>
-  <clipPath id='cpMTYwLjE3fDMxNC44NnwyMi43OHw1NzAuNTI='>
-    <rect x='160.17' y='22.78' width='154.69' height='547.74' />
+  <clipPath id='cpMTY1LjIxfDMxMi4zNHwyMi43OHw1NzAuNTI='>
+    <rect x='165.21' y='22.78' width='147.14' height='547.74' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMTYwLjE3fDMxNC44NnwyMi43OHw1NzAuNTI=)'>
-<rect x='160.17' y='22.78' width='154.69' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpMTY1LjIxfDMxMi4zNHwyMi43OHw1NzAuNTI=)'>
+<rect x='165.21' y='22.78' width='147.14' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMTk3Ljg2fDMwOS4zOHw0NS41N3w1MzkuNjM='>
-    <rect x='197.86' y='45.57' width='111.52' height='494.07' />
+  <clipPath id='cpMTkwLjMwfDMwNi44Nnw0NS41N3w1MzkuNjM='>
+    <rect x='190.30' y='45.57' width='116.56' height='494.07' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMTk3Ljg2fDMwOS4zOHw0NS41N3w1MzkuNjM=)'>
-<rect x='197.86' y='45.57' width='111.52' height='494.07' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='248.66' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='248.66' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='256.43' cy='475.83' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='250.39' cy='307.78' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='238.74' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='236.15' cy='344.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='219.75' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='263.33' cy='432.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='256.43' cy='439.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='240.89' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='234.85' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='228.81' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='232.70' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='223.64' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='202.93' cy='68.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='202.93' cy='81.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='221.48' cy='103.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='297.84' cy='508.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='289.21' cy='512.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='304.31' cy='517.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='250.82' cy='462.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='224.93' cy='240.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='223.64' cy='256.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='215.44' cy='204.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='240.89' cy='148.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='275.84' cy='508.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='270.23' cy='462.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='289.21' cy='490.29' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='226.23' cy='203.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='243.05' cy='434.38' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='222.77' cy='259.61' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='250.39' cy='461.27' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='197.86' y='45.57' width='111.52' height='494.07' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMTkwLjMwfDMwNi44Nnw0NS41N3w1MzkuNjM=)'>
+<rect x='190.30' y='45.57' width='116.56' height='494.07' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='243.40' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='243.40' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='251.51' cy='475.83' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='245.20' cy='307.78' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='233.03' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='230.32' cy='344.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='213.19' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='258.73' cy='432.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='251.51' cy='439.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='235.28' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='228.97' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='222.66' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='226.71' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='217.25' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='195.60' cy='68.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='195.60' cy='81.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='214.99' cy='103.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='294.80' cy='508.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='285.78' cy='512.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='301.57' cy='517.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='245.65' cy='462.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='218.60' cy='240.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='217.25' cy='256.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.68' cy='204.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='235.28' cy='148.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='271.81' cy='508.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='265.94' cy='462.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='285.78' cy='490.29' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='219.95' cy='203.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='237.54' cy='434.38' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='216.34' cy='259.61' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='245.20' cy='461.27' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='190.30' y='45.57' width='116.56' height='494.07' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='192.93' y='487.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='192.93' y='375.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
-<text x='192.93' y='263.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
-<text x='192.93' y='151.72' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
-<polyline points='195.12,484.80 197.86,484.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='195.12,372.76 197.86,372.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='195.12,260.73 197.86,260.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='195.12,148.69 197.86,148.69 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='201.20,542.37 201.20,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='222.77,542.37 222.77,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='244.35,542.37 244.35,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='265.92,542.37 265.92,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='287.49,542.37 287.49,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='309.06,542.37 309.06,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='201.20' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='222.77' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='244.35' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='265.92' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='287.49' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='309.06' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
-<text x='197.86' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+<text x='185.37' y='487.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='185.37' y='375.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='185.37' y='263.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='185.37' y='151.72' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='187.56,484.80 190.30,484.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='187.56,372.76 190.30,372.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='187.56,260.73 190.30,260.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='187.56,148.69 190.30,148.69 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='193.80,542.37 193.80,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='216.34,542.37 216.34,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='238.89,542.37 238.89,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='261.44,542.37 261.44,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='283.98,542.37 283.98,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='306.53,542.37 306.53,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='193.80' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='216.34' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='238.89' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='261.44' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='283.98' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='306.53' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='190.30' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
 </g>
 <defs>
-  <clipPath id='cpMzE0Ljg2fDQzNy4zNXwyMi43OHw1NzAuNTI='>
-    <rect x='314.86' y='22.78' width='122.48' height='547.74' />
+  <clipPath id='cpMzEyLjM0fDQzOS44NnwyMi43OHw1NzAuNTI='>
+    <rect x='312.34' y='22.78' width='127.52' height='547.74' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzE0Ljg2fDQzNy4zNXwyMi43OHw1NzAuNTI=)'>
-<rect x='314.86' y='22.78' width='122.48' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-</g>
-<defs>
-  <clipPath id='cpMzIwLjM0fDQzMS44N3w0NS41N3w1MzkuNjM='>
-    <rect x='320.34' y='45.57' width='111.52' height='494.07' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMzIwLjM0fDQzMS44N3w0NS41N3w1MzkuNjM=)'>
-<rect x='320.34' y='45.57' width='111.52' height='494.07' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='371.14' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='371.14' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='378.91' cy='475.83' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='372.87' cy='307.78' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='361.22' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='358.63' cy='344.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='342.24' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='385.81' cy='432.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='378.91' cy='439.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='363.38' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='357.34' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='351.30' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='355.18' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='346.12' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='325.41' cy='68.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='325.41' cy='81.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='343.96' cy='103.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='420.33' cy='508.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='411.70' cy='512.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='426.80' cy='517.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='373.30' cy='462.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='347.41' cy='240.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='346.12' cy='256.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='337.92' cy='204.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='363.38' cy='148.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='398.32' cy='508.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='392.71' cy='462.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='411.70' cy='490.29' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='348.71' cy='203.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='365.53' cy='434.38' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='345.26' cy='259.61' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='372.87' cy='461.27' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='320.34' y='45.57' width='111.52' height='494.07' style='stroke-width: 1.07; stroke: #333333;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='323.69,542.37 323.69,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='345.26,542.37 345.26,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='366.83,542.37 366.83,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='388.40,542.37 388.40,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='409.97,542.37 409.97,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='431.54,542.37 431.54,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='323.69' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='345.26' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='366.83' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='388.40' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='409.97' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='431.54' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
-<text x='320.34' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
-</g>
-<defs>
-  <clipPath id='cpNDM3LjM1fDU5Mi4wNHwyMi43OHwyODMuOTU='>
-    <rect x='437.35' y='22.78' width='154.69' height='261.16' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNDM3LjM1fDU5Mi4wNHwyMi43OHwyODMuOTU=)'>
-<rect x='437.35' y='22.78' width='154.69' height='261.16' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpMzEyLjM0fDQzOS44NnwyMi43OHw1NzAuNTI=)'>
+<rect x='312.34' y='22.78' width='127.52' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDc1LjAzfDU4Ni41Nnw0NS41N3wyNzguNDc='>
-    <rect x='475.03' y='45.57' width='111.52' height='232.90' />
+  <clipPath id='cpMzE3LjgyfDQzNC4zOXw0NS41N3w1MzkuNjM='>
+    <rect x='317.82' y='45.57' width='116.56' height='494.07' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDc1LjAzfDU4Ni41Nnw0NS41N3wyNzguNDc=)'>
-<rect x='475.03' y='45.57' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='525.83' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='525.83' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='533.60' cy='248.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='527.56' cy='169.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='515.91' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='513.32' cy='186.60' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='496.93' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='540.50' cy='227.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='533.60' cy='231.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='518.07' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='512.03' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='505.99' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='509.87' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='500.81' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='480.10' cy='56.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='480.10' cy='62.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='498.65' cy='73.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='575.02' cy='263.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='566.39' cy='265.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='581.49' cy='267.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='527.99' cy='242.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='502.11' cy='137.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='500.81' cy='144.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='492.61' cy='120.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='518.07' cy='94.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='553.01' cy='263.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='547.41' cy='241.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='566.39' cy='255.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='503.40' cy='120.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='520.23' cy='228.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='499.95' cy='146.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='527.56' cy='241.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='475.03' y='45.57' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzE3LjgyfDQzNC4zOXw0NS41N3w1MzkuNjM=)'>
+<rect x='317.82' y='45.57' width='116.56' height='494.07' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='370.92' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='370.92' cy='417.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='379.04' cy='475.83' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='372.72' cy='307.78' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='360.55' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='357.84' cy='344.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='340.71' cy='193.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='386.25' cy='432.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='379.04' cy='439.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='362.80' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='356.49' cy='409.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='350.18' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='354.23' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='344.77' cy='287.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='323.12' cy='68.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='323.12' cy='81.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='342.51' cy='103.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='422.32' cy='508.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='413.30' cy='512.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='429.09' cy='517.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='373.17' cy='462.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='346.12' cy='240.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='344.77' cy='256.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='336.20' cy='204.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='362.80' cy='148.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='399.33' cy='508.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='393.46' cy='462.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='413.30' cy='490.29' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='347.47' cy='203.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='365.06' cy='434.38' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='343.86' cy='259.61' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='372.72' cy='461.27' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='317.82' y='45.57' width='116.56' height='494.07' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='470.10' y='255.65' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='470.10' y='202.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
-<text x='470.10' y='150.02' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
-<text x='470.10' y='97.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
-<polyline points='472.29,252.62 475.03,252.62 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.29,199.81 475.03,199.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.29,146.99 475.03,146.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.29,94.18 475.03,94.18 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='475.03' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+<polyline points='321.32,542.37 321.32,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='343.86,542.37 343.86,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='366.41,542.37 366.41,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='388.96,542.37 388.96,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='411.50,542.37 411.50,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='434.05,542.37 434.05,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='321.32' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='343.86' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='366.41' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='388.96' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='411.50' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='434.05' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='317.82' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
 </g>
 <defs>
-  <clipPath id='cpNTkyLjA0fDcxNC41MnwyMi43OHwyODMuOTU='>
-    <rect x='592.04' y='22.78' width='122.48' height='261.16' />
+  <clipPath id='cpNDM5Ljg2fDU4Ny4wMHwyMi43OHwyODMuOTU='>
+    <rect x='439.86' y='22.78' width='147.14' height='261.16' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTkyLjA0fDcxNC41MnwyMi43OHwyODMuOTU=)'>
-<rect x='592.04' y='22.78' width='122.48' height='261.16' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-</g>
-<defs>
-  <clipPath id='cpNTk3LjUyfDcwOS4wNHw0NS41N3wyNzguNDc='>
-    <rect x='597.52' y='45.57' width='111.52' height='232.90' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNTk3LjUyfDcwOS4wNHw0NS41N3wyNzguNDc=)'>
-<rect x='597.52' y='45.57' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='648.32' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='648.32' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='656.08' cy='248.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='650.04' cy='169.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='638.39' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='635.81' cy='186.60' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='619.41' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='662.99' cy='227.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='656.08' cy='231.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='640.55' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='634.51' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='628.47' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='632.35' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='623.29' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='602.59' cy='56.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='602.59' cy='62.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='621.14' cy='73.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='697.50' cy='263.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='688.87' cy='265.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='703.97' cy='267.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='650.47' cy='242.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='624.59' cy='137.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='623.29' cy='144.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='615.10' cy='120.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='640.55' cy='94.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='675.50' cy='263.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='669.89' cy='241.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='688.87' cy='255.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='625.88' cy='120.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='642.71' cy='228.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='622.43' cy='146.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='650.04' cy='241.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='597.52' y='45.57' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
-</g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='597.52' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
-</g>
-<defs>
-  <clipPath id='cpNS40OHwxNjAuMTd8MjgzLjk1fDU3MC41Mg=='>
-    <rect x='5.48' y='283.95' width='154.69' height='286.57' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNS40OHwxNjAuMTd8MjgzLjk1fDU3MC41Mg==)'>
-<rect x='5.48' y='283.95' width='154.69' height='286.57' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpNDM5Ljg2fDU4Ny4wMHwyMi43OHwyODMuOTU=)'>
+<rect x='439.86' y='22.78' width='147.14' height='261.16' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDMuMTd8MTU0LjY5fDMwNi43M3w1MzkuNjM='>
-    <rect x='43.17' y='306.73' width='111.52' height='232.90' />
+  <clipPath id='cpNDY0Ljk2fDU4MS41Mnw0NS41N3wyNzguNDc='>
+    <rect x='464.96' y='45.57' width='116.56' height='232.90' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuMTd8MTU0LjY5fDMwNi43M3w1MzkuNjM=)'>
-<rect x='43.17' y='306.73' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='93.97' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='93.97' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='101.73' cy='509.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='95.69' cy='430.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='84.05' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='81.46' cy='447.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='65.06' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='108.64' cy='489.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='101.73' cy='492.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='86.20' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='80.16' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='74.12' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='78.01' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='68.95' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='48.24' cy='317.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='48.24' cy='323.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='66.79' cy='334.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='143.15' cy='525.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='134.52' cy='526.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='149.62' cy='529.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='96.13' cy='503.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='70.24' cy='398.65' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='68.95' cy='406.04' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='60.75' cy='381.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='86.20' cy='355.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='121.15' cy='524.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='115.54' cy='503.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='134.52' cy='516.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='71.53' cy='381.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='88.36' cy='490.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='68.08' cy='407.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='95.69' cy='502.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='43.17' y='306.73' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNDY0Ljk2fDU4MS41Mnw0NS41N3wyNzguNDc=)'>
+<rect x='464.96' y='45.57' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='518.05' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='518.05' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='526.17' cy='248.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='519.86' cy='169.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='507.68' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='504.98' cy='186.60' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='487.84' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='533.39' cy='227.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='526.17' cy='231.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='509.94' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='503.63' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='497.31' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='501.37' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.90' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='470.26' cy='56.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='470.26' cy='62.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='489.65' cy='73.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='569.46' cy='263.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='560.44' cy='265.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='576.22' cy='267.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='520.31' cy='242.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='493.25' cy='137.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.90' cy='144.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='483.33' cy='120.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='509.94' cy='94.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='546.46' cy='263.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='540.60' cy='241.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='560.44' cy='255.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='494.61' cy='120.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='512.19' cy='228.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.00' cy='146.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='519.86' cy='241.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='464.96' y='45.57' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='460.03' y='255.65' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='460.03' y='202.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='460.03' y='150.02' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='460.03' y='97.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='462.22,252.62 464.96,252.62 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.22,199.81 464.96,199.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.22,146.99 464.96,146.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.22,94.18 464.96,94.18 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='464.96' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+</g>
+<defs>
+  <clipPath id='cpNTg3LjAwfDcxNC41MnwyMi43OHwyODMuOTU='>
+    <rect x='587.00' y='22.78' width='127.52' height='261.16' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTg3LjAwfDcxNC41MnwyMi43OHwyODMuOTU=)'>
+<rect x='587.00' y='22.78' width='127.52' height='261.16' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkyLjQ4fDcwOS4wNHw0NS41N3wyNzguNDc='>
+    <rect x='592.48' y='45.57' width='116.56' height='232.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkyLjQ4fDcwOS4wNHw0NS41N3wyNzguNDc=)'>
+<rect x='592.48' y='45.57' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='645.57' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='645.57' cy='220.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='653.69' cy='248.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='647.38' cy='169.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='635.20' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='632.50' cy='186.60' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='615.36' cy='115.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='660.91' cy='227.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='653.69' cy='231.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='637.46' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='631.15' cy='216.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='624.83' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='628.89' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='619.42' cy='159.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='597.78' cy='56.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='597.78' cy='62.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='617.17' cy='73.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='696.98' cy='263.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='687.96' cy='265.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='703.74' cy='267.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='647.83' cy='242.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='620.77' cy='137.49' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='619.42' cy='144.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='610.85' cy='120.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='637.46' cy='94.18' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='673.98' cy='263.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='668.12' cy='241.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='687.96' cy='255.21' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='622.13' cy='120.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='639.71' cy='228.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='618.52' cy='146.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='647.38' cy='241.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='592.48' y='45.57' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='592.48' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjUuMjF8MjgzLjk1fDU3MC41Mg=='>
+    <rect x='5.48' y='283.95' width='159.73' height='286.57' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjUuMjF8MjgzLjk1fDU3MC41Mg==)'>
+<rect x='5.48' y='283.95' width='159.73' height='286.57' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDMuMTd8MTU5LjczfDMwNi43M3w1MzkuNjM='>
+    <rect x='43.17' y='306.73' width='116.56' height='232.90' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMTd8MTU5LjczfDMwNi43M3w1MzkuNjM=)'>
+<rect x='43.17' y='306.73' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='96.26' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='96.26' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='104.38' cy='509.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='98.07' cy='430.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='85.89' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='83.19' cy='447.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='66.05' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='111.59' cy='489.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='104.38' cy='492.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='88.15' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='81.83' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='75.52' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='79.58' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='70.11' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='48.47' cy='317.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='48.47' cy='323.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='67.86' cy='334.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='147.67' cy='525.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.65' cy='526.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='154.43' cy='529.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='98.52' cy='503.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='71.46' cy='398.65' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='70.11' cy='406.04' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='61.54' cy='381.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='88.15' cy='355.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='124.67' cy='524.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='118.81' cy='503.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.65' cy='516.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='72.82' cy='381.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='90.40' cy='490.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='69.21' cy='407.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='98.07' cy='502.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='43.17' y='306.73' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='38.24' y='516.81' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
@@ -407,165 +407,163 @@
 <polyline points='40.43,460.97 43.17,460.97 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='40.43,408.16 43.17,408.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='40.43,355.34 43.17,355.34 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='46.51,542.37 46.51,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='68.08,542.37 68.08,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='89.65,542.37 89.65,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='111.23,542.37 111.23,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='132.80,542.37 132.80,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='154.37,542.37 154.37,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='46.51' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='68.08' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='89.65' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='111.23' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='132.80' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='154.37' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<polyline points='46.66,542.37 46.66,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='69.21,542.37 69.21,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='91.75,542.37 91.75,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='114.30,542.37 114.30,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='136.85,542.37 136.85,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='159.39,542.37 159.39,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='46.66' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='69.21' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='91.75' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='114.30' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='136.85' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='159.39' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
 <text x='43.17' y='298.51' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
 </g>
 <defs>
-  <clipPath id='cpNDM3LjM1fDU5Mi4wNHwyODMuOTV8NTcwLjUy'>
-    <rect x='437.35' y='283.95' width='154.69' height='286.57' />
+  <clipPath id='cpNDM5Ljg2fDU4Ny4wMHwyODMuOTV8NTcwLjUy'>
+    <rect x='439.86' y='283.95' width='147.14' height='286.57' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDM3LjM1fDU5Mi4wNHwyODMuOTV8NTcwLjUy)'>
-<rect x='437.35' y='283.95' width='154.69' height='286.57' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpNDM5Ljg2fDU4Ny4wMHwyODMuOTV8NTcwLjUy)'>
+<rect x='439.86' y='283.95' width='147.14' height='286.57' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDc1LjAzfDU4Ni41NnwzMDYuNzN8NTM5LjYz'>
-    <rect x='475.03' y='306.73' width='111.52' height='232.90' />
+  <clipPath id='cpNDY0Ljk2fDU4MS41MnwzMDYuNzN8NTM5LjYz'>
+    <rect x='464.96' y='306.73' width='116.56' height='232.90' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDc1LjAzfDU4Ni41NnwzMDYuNzN8NTM5LjYz)'>
-<rect x='475.03' y='306.73' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='525.83' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='525.83' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='533.60' cy='509.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='527.56' cy='430.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='515.91' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='513.32' cy='447.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='496.93' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='540.50' cy='489.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='533.60' cy='492.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='518.07' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='512.03' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='505.99' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='509.87' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='500.81' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='480.10' cy='317.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='480.10' cy='323.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='498.65' cy='334.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='575.02' cy='525.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='566.39' cy='526.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='581.49' cy='529.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='527.99' cy='503.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='502.11' cy='398.65' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='500.81' cy='406.04' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='492.61' cy='381.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='518.07' cy='355.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='553.01' cy='524.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='547.41' cy='503.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='566.39' cy='516.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='503.40' cy='381.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='520.23' cy='490.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='499.95' cy='407.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='527.56' cy='502.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='475.03' y='306.73' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNDY0Ljk2fDU4MS41MnwzMDYuNzN8NTM5LjYz)'>
+<rect x='464.96' y='306.73' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='518.05' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='518.05' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='526.17' cy='509.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='519.86' cy='430.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='507.68' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='504.98' cy='447.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='487.84' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='533.39' cy='489.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='526.17' cy='492.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='509.94' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='503.63' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='497.31' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='501.37' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.90' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='470.26' cy='317.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='470.26' cy='323.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='489.65' cy='334.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='569.46' cy='525.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='560.44' cy='526.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='576.22' cy='529.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='520.31' cy='503.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='493.25' cy='398.65' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.90' cy='406.04' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='483.33' cy='381.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='509.94' cy='355.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='546.46' cy='524.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='540.60' cy='503.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='560.44' cy='516.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='494.61' cy='381.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='512.19' cy='490.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.00' cy='407.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='519.86' cy='502.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='464.96' y='306.73' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='470.10' y='516.81' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='470.10' y='464.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
-<text x='470.10' y='411.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
-<text x='470.10' y='358.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
-<polyline points='472.29,513.78 475.03,513.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.29,460.97 475.03,460.97 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.29,408.16 475.03,408.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='472.29,355.34 475.03,355.34 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='478.38,542.37 478.38,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='499.95,542.37 499.95,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='521.52,542.37 521.52,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='543.09,542.37 543.09,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='564.66,542.37 564.66,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='586.23,542.37 586.23,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='478.38' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='499.95' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='521.52' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='543.09' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='564.66' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='586.23' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
-<text x='475.03' y='298.51' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+<text x='460.03' y='516.81' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='460.03' y='464.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='460.03' y='411.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='460.03' y='358.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='462.22,513.78 464.96,513.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.22,460.97 464.96,460.97 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.22,408.16 464.96,408.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.22,355.34 464.96,355.34 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='468.45,542.37 468.45,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='491.00,542.37 491.00,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='513.55,542.37 513.55,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='536.09,542.37 536.09,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='558.64,542.37 558.64,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='581.18,542.37 581.18,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='468.45' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='491.00' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='513.55' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='536.09' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='558.64' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='581.18' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='464.96' y='298.51' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
 </g>
 <defs>
-  <clipPath id='cpNTkyLjA0fDcxNC41MnwyODMuOTV8NTcwLjUy'>
-    <rect x='592.04' y='283.95' width='122.48' height='286.57' />
+  <clipPath id='cpNTg3LjAwfDcxNC41MnwyODMuOTV8NTcwLjUy'>
+    <rect x='587.00' y='283.95' width='127.52' height='286.57' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTkyLjA0fDcxNC41MnwyODMuOTV8NTcwLjUy)'>
-<rect x='592.04' y='283.95' width='122.48' height='286.57' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpNTg3LjAwfDcxNC41MnwyODMuOTV8NTcwLjUy)'>
+<rect x='587.00' y='283.95' width='127.52' height='286.57' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNTk3LjUyfDcwOS4wNHwzMDYuNzN8NTM5LjYz'>
-    <rect x='597.52' y='306.73' width='111.52' height='232.90' />
+  <clipPath id='cpNTkyLjQ4fDcwOS4wNHwzMDYuNzN8NTM5LjYz'>
+    <rect x='592.48' y='306.73' width='116.56' height='232.90' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTk3LjUyfDcwOS4wNHwzMDYuNzN8NTM5LjYz)'>
-<rect x='597.52' y='306.73' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='648.32' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='648.32' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='656.08' cy='509.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='650.04' cy='430.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='638.39' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='635.81' cy='447.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='619.41' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='662.99' cy='489.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='656.08' cy='492.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='640.55' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='634.51' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='628.47' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='632.35' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='623.29' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='602.59' cy='317.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='602.59' cy='323.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='621.14' cy='334.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='697.50' cy='525.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='688.87' cy='526.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='703.97' cy='529.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='650.47' cy='503.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='624.59' cy='398.65' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='623.29' cy='406.04' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='615.10' cy='381.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='640.55' cy='355.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='675.50' cy='524.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='669.89' cy='503.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='688.87' cy='516.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='625.88' cy='381.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='642.71' cy='490.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='622.43' cy='407.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='650.04' cy='502.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='597.52' y='306.73' width='111.52' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNTkyLjQ4fDcwOS4wNHwzMDYuNzN8NTM5LjYz)'>
+<rect x='592.48' y='306.73' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='645.57' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='645.57' cy='482.10' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='653.69' cy='509.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='647.38' cy='430.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='635.20' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='632.50' cy='447.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='615.36' cy='376.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='660.91' cy='489.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='653.69' cy='492.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='637.46' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='631.15' cy='478.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='624.83' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='628.89' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='619.42' cy='420.94' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='597.78' cy='317.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='597.78' cy='323.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='617.17' cy='334.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='696.98' cy='525.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='687.96' cy='526.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='703.74' cy='529.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='647.83' cy='503.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='620.77' cy='398.65' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='619.42' cy='406.04' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='610.85' cy='381.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='637.46' cy='355.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='673.98' cy='524.87' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='668.12' cy='503.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='687.96' cy='516.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='622.13' cy='381.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='639.71' cy='490.02' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='618.52' cy='407.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='647.38' cy='502.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='592.48' y='306.73' width='116.56' height='232.90' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='600.86,542.37 600.86,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='622.43,542.37 622.43,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='644.00,542.37 644.00,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='665.57,542.37 665.57,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='687.15,542.37 687.15,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='708.72,542.37 708.72,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='600.86' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='622.43' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='644.00' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='665.57' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='687.15' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='708.72' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
-<text x='314.86' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
-<text x='98.93' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
-<text x='592.04' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<polyline points='595.97,542.37 595.97,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='618.52,542.37 618.52,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='641.07,542.37 641.07,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='663.61,542.37 663.61,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='686.16,542.37 686.16,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='708.70,542.37 708.70,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='595.97' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='618.52' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='641.07' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='663.61' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='686.16' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='708.70' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='312.34' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='101.45' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='587.00' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
 <text transform='translate(18.53,292.60) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
-<text transform='translate(173.22,292.60) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
-<text transform='translate(450.40,292.60) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
-<text x='597.52' y='298.51' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+<text x='592.48' y='298.51' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
 <text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='187.82px' lengthAdjust='spacingAndGlyphs'>multi-cell title and axis collection</text>
 </g>
 </svg>


### PR DESCRIPTION
This PR aims to fix #349.

Briefly, when merging titles, multi-cell titles are not taken into account.
It allows cases such as the reprex from #349 to merge titles.

``` r
library(ggplot2)
devtools::load_all("~/packages/patchwork/")
#> ℹ Loading patchwork

p1 <- ggplot(mtcars) +
  geom_point(aes(mpg, disp)) +
  labs(y = "mpg", x = "collected axis title")

p2 <- ggplot(mtcars) +
  geom_boxplot(aes(gear, disp, group = gear)) +
  labs(y = "gear", x = "collected axis title")

p1 + p2 + plot_layout(axis_titles = "collect_x", design = "AAB")
```

![](https://i.imgur.com/c2qCT3j.png)<!-- -->

However, this also means that titles are merged over multi-cell titles. In the plot below, the `mpg` label is not repeated for the 2nd column, which used to be the case. The changed snapshot is related to this.

``` r
plots <- wrap_plots(rep(list(p1), 3))
layout <- plot_layout(design = "12\n32", axis_titles = "collect")
plots + layout
```

![](https://i.imgur.com/k358CZk.png)<!-- -->

<sup>Created on 2024-02-12 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

I couldn't find an elegant solution to keep both cases working, but I think the tradeoff might be worth it.
