### PR TITLE
fix: require minimum rlang version to install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     grDevices,
     utils,
     graphics,
-    rlang,
+    rlang (>= 1.0.0),
     cli
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Import rlang >=1.0.0, as patchwork installation will fail with an older rlang.

This should fix https://github.com/thomasp85/patchwork/issues/356