### PR TITLE
Ignore empty areas when collecting titles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,39 +1,40 @@
 # patchwork (development version)
 
 * `free()` now better aligns plots in horizontal direction
-* Plot backgrounds are now always placed beneath all other elements in the 
+* Plot backgrounds are now always placed beneath all other elements in the
   patchwork (#370)
-* Axis titles can now reliably be collected even with faceted plots (#367 and 
+* Axis titles can now reliably be collected even with faceted plots (#367 and
   #369)
 * Native support for gt objects
+* Empty patches no longer breaks up axis title collection (#375)
 
 # patchwork 1.2.0
 
 * Axes and axis titles can now be collected using the `plot_layout()` function.
-  Collecting axes will remove duplicated axes in the x- or y-direction. 
-  Collecting axis titles will also remove duplicated titles in the x- or 
+  Collecting axes will remove duplicated axes in the x- or y-direction.
+  Collecting axis titles will also remove duplicated titles in the x- or
   y-direction, but also merge duplicated titles in the other direction (#150).
 * Fix a bug that prevented faceted plots with axes on the right from being
   used (#340)
 * Added `free()` function to mark a plot to not be aligned with the rest. The
-  margin of the plot will still be aligned with the margins of the other plots 
-  but everything inside of that will by unaligned. 
+  margin of the plot will still be aligned with the margins of the other plots
+  but everything inside of that will by unaligned.
 
 # patchwork 1.1.3
 
 * `NULL` can now be used with the different arithmetic operators and will result
   in a non-operation (i.e. the non-null part will be returned unmodified) (#290)
-* Fix a bug that prevented plots with multi-level strips from being merged 
+* Fix a bug that prevented plots with multi-level strips from being merged
   together (#277)
-* Patchworks will now render correctly when unserialised in a fresh session, 
+* Patchworks will now render correctly when unserialised in a fresh session,
   providing the patchwork package is available (#242)
-* Fixed a bug preventing faceted plots with strip placement outside the axis 
+* Fixed a bug preventing faceted plots with strip placement outside the axis
   from being aligned (#325)
 * Fixed a bug that let to inconsistent results when combining fixed aspect plots
   in different order (#274)
-* Fixed a bug that prevented nested patchworks with empty columns or rows at the 
+* Fixed a bug that prevented nested patchworks with empty columns or rows at the
   bottom or to the right to be inserted into a layout (#273)
-* Patchwork objects now behaves more correctly like an unnamed list of ggplots. 
+* Patchwork objects now behaves more correctly like an unnamed list of ggplots.
   This makes `View()` work on them (#317), and allow one to use `length()` to
   determine the number of patches in a patchwork (#293)
 * Expressions and calls can now be used as plot annotations in the same way as
@@ -47,7 +48,7 @@
 
 * Use vdiffr conditionally to pass test on M1 mac
 * Add `str()` method to patchwork objects (#217)
-* Fix a bug in `inset_element()` when insetting plots with fixed dimensions 
+* Fix a bug in `inset_element()` when insetting plots with fixed dimensions
   (#214)
 * Make sure that `-`, `/`, and `|` works with all supported object types (#221)
 
@@ -55,20 +56,20 @@
 
 * Add `inset_element()` to allow adding plots as insets
 * patchwork now supports `raster` and `nativeRaster` objects
-* Avoid incrementing tag counter when recursing into a nested plot without 
+* Avoid incrementing tag counter when recursing into a nested plot without
   additional tags to use (#147)
-* Fix bug that prevented strips turned off with `element_blank()` from working 
+* Fix bug that prevented strips turned off with `element_blank()` from working
   (#200)
-* Add option to supply a custom sequence of tags to use for auto-tagging (#211, 
+* Add option to supply a custom sequence of tags to use for auto-tagging (#211,
   #63)
 
 # patchwork 1.0.1
 
 * Renaming of `align_plots()` to `align_patches()` to avoid namespace clash
   with cowplot (#130)
-* Renaming of `as_grob()` (unexported) to `as_patch()` to avoid potential 
+* Renaming of `as_grob()` (unexported) to `as_patch()` to avoid potential
   future namespace clash with cowplot (#131)
-* Fix bug in plot simplification with `theme(strip.placement = 'outside')` 
+* Fix bug in plot simplification with `theme(strip.placement = 'outside')`
   (#132)
 * Fix a bug in guide collection in R >= 4.0 due to the new unit implementation
   in grid (#170)
@@ -76,7 +77,7 @@
   (#137)
 * Fix a bug in base graphic support where the environment of the plot was not
   captured (#138)
-* Fix a bug when combining plots having guides placed manually in combination 
+* Fix a bug when combining plots having guides placed manually in combination
   with faceting (#144)
 * Fix a bug where having negative margins around the legend would result in an
   unintelligeble error (#148)
@@ -84,7 +85,7 @@
 * Fix alignments of strips when only a single strip is present (#163)
 * Fix a bug that caused theme void to result in errors (#180)
 * Make aligning multiple fixed aspect plots more consistent (#175)
-* Correct alignment of guides when ssembling fixed aspect plots (#140, 
+* Correct alignment of guides when ssembling fixed aspect plots (#140,
   @ilia-kats)
 
 # patchwork 1.0.0

--- a/R/collect_axes.R
+++ b/R/collect_axes.R
@@ -24,7 +24,8 @@ collect_axis_titles <- function(gt, dir = "x", merge = TRUE) {
 
     # Simplify layout of grobs to matrix
     layout <- grob_layout(gt, c(idx, patch_index))
-    layout[layout %in% patch_index] <- NA # Remove patches
+    nested <- layout %in% patch_index
+    layout[nested] <- NA # Remove patches
 
     # Mark duplicated grobs
     structure <- grob_id(gt$grobs, layout, byrow = dir == "x", merge = merge, unpack = TRUE)
@@ -34,36 +35,47 @@ collect_axis_titles <- function(gt, dir = "x", merge = TRUE) {
       next
     }
 
+    structure[nested] <- 0
+
     # Identify 'run'-rectangles in the structure
-    runs <- rle_2d(structure, byrow = dir == "y")
-    runs <- runs[!is.na(runs$value), , drop = FALSE]
+    runs <- rle_2d(structure, byrow = dir == "y", ignore.na = TRUE)
+    runs <- runs[!is.na(runs$value) & runs$value != 0, , drop = FALSE]
 
-    # Find first grob in run
-    start_runs <- c("row_start", "col_start")
-    if (name == "xlab-b") start_runs[1] <- "row_end"
-    if (name == "ylab-r") start_runs[2] <- "col_end"
-    start_idx <- layout[as.matrix(runs[, start_runs])]
+    # Get all panels in each run and put the keeper first
+    panels <- lapply(seq_len(nrow(runs)), function(i) {
+      rows <- runs$row_start[i]:runs$row_end[i]
+      cols <- runs$col_start[i]:runs$col_end[i]
+      first <- switch(name,
+        "xlab-t" = layout[runs$row_start[i], cols],
+        "xlab-b" = layout[runs$row_end[i]],
+        "ylab-l" = layout[rows, runs$col_start[i]],
+        "ylab-r" = layout[rows, runs$col_end[i]]
+      )
+      first <- first[!is.na(first)][1]
+      panels <- as.vector(layout[rows , cols])
+      panels <- panels[!is.na(panels)]
+      unique(c(first, panels))
+    })
 
-    # Find last grob in run
-    end_runs <- c("row_end", "col_end")
-    if (name == "xlab-t") end_runs[1] <- "row_start"
-    if (name == "ylab-l") end_runs[2] <- "col_start"
-    end_idx <- layout[as.matrix(runs[, end_runs])]
+    title_grob <- vapply(panels, `[[`, numeric(1), 1)
 
     # Mark every non-start grob for deletion
-    delete <- c(delete, setdiff(idx, start_idx))
+    delete <- c(delete, setdiff(idx, title_grob))
 
-    if (all(start_idx == end_idx)) {
+    if ((dir == "x" && all(runs$col_start == runs$col_end)) ||
+        (dir == "y" && all(runs$row_start == runs$row_end))) {
       next
     }
 
     # Stretch titles over span
     if (dir == "y") {
-      gt$layout$b[start_idx] <- gt$layout$b[end_idx]
-      gt$layout$z[start_idx] <- max(gt$layout$z[idx])
+      gt$layout$t[title_grob] <- vapply(panels, function(i) min(gt$layout$t[i]), numeric(1))
+      gt$layout$b[title_grob] <- vapply(panels, function(i) max(gt$layout$b[i]), numeric(1))
+      gt$layout$z[title_grob] <- max(gt$layout$z[idx])
     } else {
-      gt$layout$r[start_idx] <- gt$layout$r[end_idx]
-      gt$layout$z[start_idx] <- max(gt$layout$z[idx])
+      gt$layout$l[title_grob] <- vapply(panels, function(i) min(gt$layout$l[i]), numeric(1))
+      gt$layout$r[title_grob] <- vapply(panels, function(i) max(gt$layout$r[i]), numeric(1))
+      gt$layout$z[title_grob] <- max(gt$layout$z[idx])
     }
   }
   delete_grobs(gt, delete)
@@ -336,7 +348,7 @@ on_load({
 # #> 2         1       2         3       3     2
 # #> 5         3       3         1       2     3
 # #> 6         3       3         3       3     1
-rle_2d <- function(m, byrow = FALSE) {
+rle_2d <- function(m, byrow = FALSE, ignore.na = FALSE) {
 
   n <- length(m)
 
@@ -370,13 +382,13 @@ rle_2d <- function(m, byrow = FALSE) {
   levels <- unique(as.vector(m))
 
   # Simplified case when there is just a single level
-  if (length(levels) == 1L) {
+  if ((ignore.na && sum(!is.na(levels)) == 1) || length(levels) == 1L) {
     ans <- data.frame(
       col_start = 1L,
       col_end   = dim[2],
       row_start = 1L,
       row_end   = dim[1],
-      value     = m[1]
+      value     = sort(levels, na.last = TRUE)[1]
     )
     return(rename(ans))
   }

--- a/R/collect_axes.R
+++ b/R/collect_axes.R
@@ -47,7 +47,7 @@ collect_axis_titles <- function(gt, dir = "x", merge = TRUE) {
       cols <- runs$col_start[i]:runs$col_end[i]
       first <- switch(name,
         "xlab-t" = layout[runs$row_start[i], cols],
-        "xlab-b" = layout[runs$row_end[i]],
+        "xlab-b" = layout[runs$row_end[i], cols],
         "ylab-l" = layout[rows, runs$col_start[i]],
         "ylab-r" = layout[rows, runs$col_end[i]]
       )

--- a/tests/testthat/_snaps/collect_axes/empty-areas-doesn-t-interfere-with-title-collection.svg
+++ b/tests/testthat/_snaps/collect_axes/empty-areas-doesn-t-interfere-with-title-collection.svg
@@ -1,0 +1,439 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMTd8NzA5LjA0fDQ1LjU3fDUzOS42Mw=='>
+    <rect x='43.17' y='45.57' width='665.87' height='494.07' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMTd8NzA5LjA0fDQ1LjU3fDUzOS42Mw==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjUwLjIyfDQ4Mi4zN3wyMi43OHwyMDEuMTY='>
+    <rect x='250.22' y='22.78' width='232.15' height='178.38' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjUwLjIyfDQ4Mi4zN3wyMi43OHwyMDEuMTY=)'>
+<rect x='250.22' y='22.78' width='232.15' height='178.38' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDgyLjM3fDcxNC41MnwyMi43OHwyMDEuMTY='>
+    <rect x='482.37' y='22.78' width='232.15' height='178.38' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDgyLjM3fDcxNC41MnwyMi43OHwyMDEuMTY=)'>
+<rect x='482.37' y='22.78' width='232.15' height='178.38' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwyNTAuMjJ8MjAxLjE2fDM3OS41NQ=='>
+    <rect x='5.48' y='201.16' width='244.74' height='178.38' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwyNTAuMjJ8MjAxLjE2fDM3OS41NQ==)'>
+<rect x='5.48' y='201.16' width='244.74' height='178.38' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDgyLjM3fDcxNC41MnwyMDEuMTZ8Mzc5LjU1'>
+    <rect x='482.37' y='201.16' width='232.15' height='178.38' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDgyLjM3fDcxNC41MnwyMDEuMTZ8Mzc5LjU1)'>
+<rect x='482.37' y='201.16' width='232.15' height='178.38' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwyNTAuMjJ8Mzc5LjU1fDU3MC41Mg=='>
+    <rect x='5.48' y='379.55' width='244.74' height='190.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwyNTAuMjJ8Mzc5LjU1fDU3MC41Mg==)'>
+<rect x='5.48' y='379.55' width='244.74' height='190.97' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjUwLjIyfDQ4Mi4zN3wzNzkuNTV8NTcwLjUy'>
+    <rect x='250.22' y='379.55' width='232.15' height='190.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjUwLjIyfDQ4Mi4zN3wzNzkuNTV8NTcwLjUy)'>
+<rect x='250.22' y='379.55' width='232.15' height='190.97' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjMyfDQ3Ni44OXw0NS41N3wxODIuODc='>
+    <rect x='275.32' y='45.57' width='201.58' height='137.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjMyfDQ3Ni44OXw0NS41N3wxODIuODc=)'>
+<rect x='275.32' y='45.57' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='367.14' cy='148.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='367.14' cy='148.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='381.17' cy='165.14' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='370.26' cy='118.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='349.20' cy='86.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='344.52' cy='128.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='314.89' cy='86.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='393.65' cy='153.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='381.17' cy='154.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='353.10' cy='146.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='342.18' cy='146.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='331.27' cy='112.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='338.28' cy='112.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='321.91' cy='112.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='284.48' cy='51.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='284.48' cy='55.54' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='318.01' cy='61.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='456.03' cy='174.26' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='440.44' cy='175.20' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='467.73' cy='176.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='371.04' cy='161.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='324.25' cy='99.76' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='321.91' cy='104.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='307.09' cy='89.79' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='353.10' cy='74.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='416.26' cy='174.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='406.13' cy='161.31' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='440.44' cy='169.16' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='326.59' cy='89.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='357.00' cy='153.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='320.35' cy='105.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='370.26' cy='161.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='275.32' y='45.57' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='270.39' y='170.66' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='270.39' y='139.52' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='270.39' y='108.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='270.39' y='77.25' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='272.58,167.63 275.32,167.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='272.58,136.50 275.32,136.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='272.58,105.36 275.32,105.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='272.58,74.23 275.32,74.23 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='281.36,185.61 281.36,182.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='320.35,185.61 320.35,182.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='359.34,185.61 359.34,182.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='398.33,185.61 398.33,182.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='437.32,185.61 437.32,182.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='476.31,185.61 476.31,182.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='281.36' y='193.86' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='320.35' y='193.86' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='359.34' y='193.86' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='398.33' y='193.86' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='437.32' y='193.86' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='476.31' y='193.86' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='275.32' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+</g>
+<defs>
+  <clipPath id='cpNTA3LjQ3fDcwOS4wNHw0NS41N3wxODIuODc='>
+    <rect x='507.47' y='45.57' width='201.58' height='137.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTA3LjQ3fDcwOS4wNHw0NS41N3wxODIuODc=)'>
+<rect x='507.47' y='45.57' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='599.29' cy='148.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='599.29' cy='148.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='613.32' cy='165.14' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='602.41' cy='118.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='581.35' cy='86.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='576.67' cy='128.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='547.04' cy='86.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='625.80' cy='153.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='613.32' cy='154.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='585.25' cy='146.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='574.33' cy='146.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='563.42' cy='112.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='570.43' cy='112.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='554.06' cy='112.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='516.63' cy='51.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='516.63' cy='55.54' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='550.16' cy='61.77' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='688.18' cy='174.26' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='672.59' cy='175.20' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='699.88' cy='176.63' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='603.18' cy='161.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='556.40' cy='99.76' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='554.06' cy='104.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='539.24' cy='89.79' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='585.25' cy='74.23' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='648.41' cy='174.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='638.28' cy='161.31' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='672.59' cy='169.16' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='558.74' cy='89.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='589.15' cy='153.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='552.50' cy='105.05' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='602.41' cy='161.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='507.47' y='45.57' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='507.47' y='37.35' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+</g>
+<defs>
+  <clipPath id='cpNDMuMTd8MjQ0Ljc0fDIyMy45NXwzNjEuMjU='>
+    <rect x='43.17' y='223.95' width='201.58' height='137.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMTd8MjQ0Ljc0fDIyMy45NXwzNjEuMjU=)'>
+<rect x='43.17' y='223.95' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='134.99' cy='327.33' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='134.99' cy='327.33' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='149.02' cy='343.52' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.11' cy='296.82' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='117.05' cy='265.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='112.37' cy='307.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='82.74' cy='265.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='161.50' cy='331.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='149.02' cy='333.31' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='120.95' cy='324.97' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='110.03' cy='324.97' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='99.12' cy='291.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='106.14' cy='291.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='89.76' cy='291.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='52.33' cy='230.19' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='52.33' cy='233.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='85.86' cy='240.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='223.88' cy='352.64' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.29' cy='353.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='235.58' cy='355.01' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.89' cy='339.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='92.10' cy='278.14' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='89.76' cy='282.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='74.94' cy='268.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='120.95' cy='252.61' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='184.11' cy='352.55' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='173.98' cy='339.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.29' cy='347.54' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='94.44' cy='267.86' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='124.85' cy='332.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='88.20' cy='283.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.11' cy='339.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='43.17' y='223.95' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.24' y='349.04' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='38.24' y='317.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='38.24' y='286.77' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='38.24' y='255.63' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='40.43,346.01 43.17,346.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.43,314.88 43.17,314.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.43,283.74 43.17,283.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.43,252.61 43.17,252.61 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='43.17' y='215.73' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+</g>
+<defs>
+  <clipPath id='cpNTA3LjQ3fDcwOS4wNHwyMjMuOTV8MzYxLjI1'>
+    <rect x='507.47' y='223.95' width='201.58' height='137.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTA3LjQ3fDcwOS4wNHwyMjMuOTV8MzYxLjI1)'>
+<rect x='507.47' y='223.95' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='599.29' cy='327.33' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='599.29' cy='327.33' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='613.32' cy='343.52' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='602.41' cy='296.82' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='581.35' cy='265.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='576.67' cy='307.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='547.04' cy='265.06' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='625.80' cy='331.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='613.32' cy='333.31' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='585.25' cy='324.97' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='574.33' cy='324.97' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='563.42' cy='291.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='570.43' cy='291.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='554.06' cy='291.28' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='516.63' cy='230.19' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='516.63' cy='233.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='550.16' cy='240.15' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='688.18' cy='352.64' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='672.59' cy='353.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='699.88' cy='355.01' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='603.18' cy='339.75' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='556.40' cy='278.14' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='554.06' cy='282.50' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='539.24' cy='268.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='585.25' cy='252.61' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='648.41' cy='352.55' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='638.28' cy='339.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='672.59' cy='347.54' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='558.74' cy='267.86' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='589.15' cy='332.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='552.50' cy='283.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='602.41' cy='339.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='507.47' y='223.95' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='502.53' y='349.04' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='502.53' y='317.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='502.53' y='286.77' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='502.53' y='255.63' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='504.73,346.01 507.47,346.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.73,314.88 507.47,314.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.73,283.74 507.47,283.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='504.73,252.61 507.47,252.61 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='513.51,363.99 513.51,361.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='552.50,363.99 552.50,361.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='591.49,363.99 591.49,361.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='630.48,363.99 630.48,361.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='669.47,363.99 669.47,361.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='708.46,363.99 708.46,361.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='513.51' y='372.24' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='552.50' y='372.24' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='591.49' y='372.24' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='630.48' y='372.24' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='669.47' y='372.24' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='708.46' y='372.24' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='507.47' y='215.73' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+</g>
+<defs>
+  <clipPath id='cpNDMuMTd8MjQ0Ljc0fDQwMi4zM3w1MzkuNjM='>
+    <rect x='43.17' y='402.33' width='201.58' height='137.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMTd8MjQ0Ljc0fDQwMi4zM3w1MzkuNjM=)'>
+<rect x='43.17' y='402.33' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='134.99' cy='505.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='134.99' cy='505.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='149.02' cy='521.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.11' cy='475.20' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='117.05' cy='443.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='112.37' cy='485.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='82.74' cy='443.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='161.50' cy='509.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='149.02' cy='511.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='120.95' cy='503.35' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='110.03' cy='503.35' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='99.12' cy='469.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='106.14' cy='469.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='89.76' cy='469.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='52.33' cy='408.57' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='52.33' cy='412.31' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='85.86' cy='418.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='223.88' cy='531.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.29' cy='531.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='235.58' cy='533.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.89' cy='518.14' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='92.10' cy='456.52' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='89.76' cy='460.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='74.94' cy='446.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='120.95' cy='430.99' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='184.11' cy='530.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='173.98' cy='518.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='208.29' cy='525.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='94.44' cy='446.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='124.85' cy='510.38' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='88.20' cy='461.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='138.11' cy='517.86' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='43.17' y='402.33' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.24' y='527.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='38.24' y='496.29' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='38.24' y='465.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='38.24' y='434.02' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='40.43,524.39 43.17,524.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.43,493.26 43.17,493.26 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.43,462.12 43.17,462.12 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.43,430.99 43.17,430.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='49.21,542.37 49.21,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='88.20,542.37 88.20,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='127.19,542.37 127.19,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='166.18,542.37 166.18,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='205.17,542.37 205.17,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='244.16,542.37 244.16,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='49.21' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='88.20' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='127.19' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='166.18' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='205.17' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='244.16' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='43.17' y='394.11' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjMyfDQ3Ni44OXw0MDIuMzN8NTM5LjYz'>
+    <rect x='275.32' y='402.33' width='201.58' height='137.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjMyfDQ3Ni44OXw0MDIuMzN8NTM5LjYz)'>
+<rect x='275.32' y='402.33' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='367.14' cy='505.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='367.14' cy='505.71' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='381.17' cy='521.90' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='370.26' cy='475.20' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='349.20' cy='443.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='344.52' cy='485.47' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='314.89' cy='443.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='393.65' cy='509.85' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='381.17' cy='511.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='353.10' cy='503.35' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='342.18' cy='503.35' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='331.27' cy='469.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='338.28' cy='469.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='321.91' cy='469.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='284.48' cy='408.57' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='284.48' cy='412.31' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='318.01' cy='418.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='456.03' cy='531.03' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='440.44' cy='531.96' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='467.73' cy='533.39' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='371.04' cy='518.14' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='324.25' cy='456.52' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='321.91' cy='460.88' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='307.09' cy='446.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='353.10' cy='430.99' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='416.26' cy='530.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='406.13' cy='518.07' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='440.44' cy='525.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='326.59' cy='446.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='357.00' cy='510.38' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='320.35' cy='461.81' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='370.26' cy='517.86' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='275.32' y='402.33' width='201.58' height='137.30' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='281.36,542.37 281.36,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='320.35,542.37 320.35,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='359.34,542.37 359.34,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='398.33,542.37 398.33,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='437.32,542.37 437.32,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='476.31,542.37 476.31,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='281.36' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='320.35' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='359.34' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='398.33' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='437.32' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='476.31' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<text x='376.10' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text transform='translate(18.53,292.60) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='275.32' y='394.11' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='282.08px' lengthAdjust='spacingAndGlyphs'>Empty areas doesn't interfere with title collection</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/collect_axes/multi-cell-title-and-axis-collection.svg
+++ b/tests/testthat/_snaps/collect_axes/multi-cell-title-and-axis-collection.svg
@@ -559,9 +559,7 @@
 <text x='663.61' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
 <text x='686.16' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
 <text x='708.70' y='550.62' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
-<text x='312.34' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
-<text x='101.45' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
-<text x='587.00' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='376.10' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
 <text transform='translate(18.53,292.60) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
 <text x='592.48' y='298.51' style='font-size: 13.20px; font-family: sans;' textLength='33.76px' lengthAdjust='spacingAndGlyphs'>Plot 1</text>
 <text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='187.82px' lengthAdjust='spacingAndGlyphs'>multi-cell title and axis collection</text>

--- a/tests/testthat/test-collect_axes.R
+++ b/tests/testthat/test-collect_axes.R
@@ -32,3 +32,16 @@ test_that("axis columns are properly resized", {
     p5 + p5 + p5 + p6 + layout
   )
 })
+
+test_that("axis titles are collected across empty areas", {
+  plots <- wrap_plots(rep(list(p1), 6)) +
+    plot_layout(
+      axes = "collect",
+      axis_titles = "collect",
+      design = "#AB\nC#D\nEF#"
+    )
+    expect_doppelganger(
+      "Empty areas doesn't interfere with title collection",
+      plots
+    )
+})


### PR DESCRIPTION
Fix #375 

Previously, the existence of empty areas would trip up axis title collection. With this PR empty areas are ignored in the case when all plots has the same title. It wasn't obvious to me how it should behave in the case of multiple titles being collected to various places so I decided on only solving the simple "facet_wrap"-like case.

@teunbrand this changes a visual test. It is not obvious to me why the previous result was correct