### PR TITLE
fix: respect `theme(strip.placement)` when strip position is ambiguous

### DIFF
--- a/R/plot_multipage.R
+++ b/R/plot_multipage.R
@@ -116,7 +116,7 @@ ggplot_build.fixed_dim_ggplot <- function(plot, ...) {
 ggplot_gtable.fixed_dim_build <- function(data) {
   dim <- data$plot$fixed_dimensions
   table <- NextMethod()
-  table <- add_strips(table)
+  table <- add_strips(table, data$plot$theme)
   table <- add_guides(table, FALSE)
   panel_pos <- find_panel(table)
   table$widths[seq_len(panel_pos$l - 1)] <- unit(dim$l, 'mm')

--- a/R/wrap_ggplot_grob.R
+++ b/R/wrap_ggplot_grob.R
@@ -46,13 +46,19 @@ wrap_ggplot_grob <- function(x) {
   attr(patch, 'table') <- x
   patch
 }
+
+#' @importFrom ggplot2 ggplot_build ggplot_gtable
+#' @importFrom gtable gtable_add_grob
 #' @export
 patchGrob.table_patch <- function(x, guides = 'auto') {
+  data <- ggplot_build(x)
   gt <- attr(x, 'table')
-  gt <- add_strips(gt)
+  # use the completed theme when adding strips
+  gt <- add_strips(gt, data$plot$theme)
   gt <- add_guides(gt, guides == 'collect')
   if ("tag" %in% names(x$labels)) {
-    plot <- add_guides(add_strips(ggplotGrob(x)))
+    # use the completed theme when adding strips
+    plot <- add_guides(add_strips(ggplot_gtable(data), data$plot$theme))
     tag_idx <- which(plot$layout$name == "tag")
     gt <- gtable_add_grob(
       gt,


### PR DESCRIPTION
fix https://github.com/thomasp85/patchwork/issues/446

This PR ensures that `add_strips()` respects the `strip.placement` setting in the theme.

```r
library(ggplot2)

set_theme(theme_classic() + theme(strip.placement = "outside"))

p1 <- ggplot(mtcars) + geom_point(aes(mpg, disp))
p2 <- ggplot(mtcars) + geom_boxplot(aes(gear, disp, group = gear))
p3 <- ggplot(mtcars) + geom_bar(aes(gear)) + facet_wrap(~cyl)

p1 / (p3 | p2)
```

<img width="1540" height="1114" alt="image" src="https://github.com/user-attachments/assets/f6144830-a13c-4fc7-bf76-17a5c0d74aab" />
