### PR TITLE
Fix typos in _pkgdown.yml and plot_layout docs

### DIFF
--- a/R/plot_layout.R
+++ b/R/plot_layout.R
@@ -52,7 +52,7 @@
 #' p4 <- ggplot(mtcars) + geom_bar(aes(carb))
 #' p5 <- ggplot(mtcars) + geom_violin(aes(cyl, mpg, group = cyl))
 #'
-#' # The plots are layed out automatically by default
+#' # The plots are laid out automatically by default
 #' p1 + p2 + p3 + p4 + p5
 #'
 #' # Use byrow to change how the grid is filled out

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -32,9 +32,9 @@ reference:
 - title: Plot Composition
   desc: >
     At the heart of patchwork lies a range of powerful functions for combining
-    plots into an assembly of plots that can be layed out in a grid. Patchwork
+    plots into an assembly of plots that can be laid out in a grid. Patchwork
     provides both an extension of ggplot2's `+` based API, along with a
-    functinal interface.
+    functional interface.
   contents:
   - /.ggplot
   - wrap_plots
@@ -53,7 +53,7 @@ reference:
   - area
 - title: Alternative plot objects
   desc: >
-    patchwork is build to work with ggplot2 but standard grobs can also be
+    patchwork is built to work with ggplot2 but standard grobs can also be
     included. Further, it is possible to define empty areas if needed.
   contents:
   - wrap_elements

--- a/man/plot_layout.Rd
+++ b/man/plot_layout.Rd
@@ -77,7 +77,7 @@ p3 <- ggplot(mtcars) + geom_bar(aes(gear)) + facet_wrap(~cyl)
 p4 <- ggplot(mtcars) + geom_bar(aes(carb))
 p5 <- ggplot(mtcars) + geom_violin(aes(cyl, mpg, group = cyl))
 
-# The plots are layed out automatically by default
+# The plots are laid out automatically by default
 p1 + p2 + p3 + p4 + p5
 
 # Use byrow to change how the grid is filled out


### PR DESCRIPTION
Fixes #460

## Changes

**** (3 fixes):
-  →  (line 37 — the reported issue)
-  →  (line 35)
-  →  (line 56)

**** + **** (1 fix):
-  →  in example comment (roxygen source and generated Rd)

## Validation

- `tools::checkRd()` passes with no warnings
- Diff is 4 lines changed across 3 files, all doc-only