### PR TITLE
Fix index out of bounds in simplify_gt.gtable_patchwork()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # patchwork (development version)
 
+* Fixed `simplify_gt.gtable_patchwork()` indexing `widths` instead of
+  `heights` when computing the height of a nested patchwork, which threw
+  "index out of bounds" whenever every height in the nested layout was an
+  absolute unit
+
 # patchwork 1.3.2
 
 * Fixed a load-time bug that could throw spurious warnings

--- a/R/plot_patchwork.R
+++ b/R/plot_patchwork.R
@@ -404,7 +404,7 @@ simplify_gt.gtable_patchwork <- function(gt) {
     new_width <- unit(1, 'null')
   }
   if (all(is_abs_unit(gt$heights[panel_pos$t:panel_pos$b]))) {
-    new_height <- sum(convertHeight(gt$widths[panel_pos$t:panel_pos$b], 'mm'))
+    new_height <- sum(convertHeight(gt$heights[panel_pos$t:panel_pos$b], 'mm'))
   } else {
     new_height <- unit(1, 'null')
   }

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -101,3 +101,22 @@ test_that("various flavours of free() works", {
     free(free(p1 + p2 + p3 + p4, "label", "l"), "panel", "t") - p4 + p5 + plot_spacer()
   })
 })
+
+test_that("Nested patchworks with all-absolute-unit heights don't error", {
+  # simplify_gt.gtable_patchwork() used to index gt$widths instead of
+  # gt$heights when computing new_height, which threw "index out of bounds"
+  # as soon as a nested block's row count exceeded its column count - which
+  # happens whenever every height in the nested layout is an absolute unit
+  # (grid::unit(..., "cm")/"pt"/"in") rather than a relative one.
+  make_block <- function(n) {
+    wrap_elements(grid::textGrob(strrep("x\n", n))) + p1 +
+      plot_layout(
+        ncol = 1,
+        heights = grid::unit.c(grid::unit(n, "cm"), grid::unit(5, "cm"))
+      )
+  }
+
+  nested <- wrap_plots(list(make_block(1), make_block(3)), ncol = 1)
+
+  expect_no_error(patchworkGrob(nested))
+})


### PR DESCRIPTION
## Summary

`simplify_gt.gtable_patchwork()` computes the collapsed height of a nested
patchwork from `gt$widths[panel_pos$t:panel_pos$b]` instead of
`gt$heights[panel_pos$t:panel_pos$b]`:

```r
if (all(is_abs_unit(gt$heights[panel_pos$t:panel_pos$b]))) {
  new_height <- sum(convertHeight(gt$widths[panel_pos$t:panel_pos$b], 'mm'))
  #                                ^^^^^^^ should be gt$heights
} else {
  new_height <- unit(1, 'null')
}
```

`gt$widths` only has one entry per *column*, so as soon as a nested block's
row range (`panel_pos$t:panel_pos$b`) exceeds the table's column count -
which happens whenever every height in the nested layout is an absolute
unit (`unit(x, "cm")`/`"pt"`/`"in"`, i.e. `is_abs_unit()` is `TRUE` for all
of them) - the index goes out of bounds and printing/building the
patchwork fails with:

```
Error: index out of bounds ("unit" subsetting)
```

Using a context-relative unit (e.g. `"line"`) for at least one height
avoids the bug, since `is_abs_unit()` then returns `FALSE` and the safe
`else` branch is taken instead - that's how I traced it back to this line.
Introduced in 556874d9 ("General solution to inheriting dimensions from
plot/table").

## Reproducible example

```r
library(ggplot2)
library(patchwork)
library(grid)

make_block <- function(n_lines) {
  title <- textGrob(paste(rep("label line", n_lines), collapse = "\n"))
  plot  <- ggplot(mtcars, aes(mpg, wt)) + geom_point()
  wrap_elements(title) + plot +
    plot_layout(ncol = 1, heights = unit.c(unit(n_lines, "cm"), unit(5, "cm")))
}

combined <- wrap_plots(list(make_block(1), make_block(3)), ncol = 1)
ggsave("reprex.pdf", combined, width = 5, height = 8)
#> Error: index out of bounds ("unit" subsetting)
```

## Changes

- `R/plot_patchwork.R`: one-line fix, `gt$widths` → `gt$heights` in the
  `new_height` branch.
- `tests/testthat/test-layout.R`: regression test reproducing the crash
  above and asserting `patchworkGrob()` no longer errors on it.
- `NEWS.md`: changelog entry.

## Test plan

- [x] Confirmed the added test fails against unpatched `patchwork` 1.3.2
      and passes after the fix (verified locally, both via a direct
      `patchworkGrob()` call and via `testthat::test_file()`).
- [x] Ran `tests/testthat/test-layout.R` with `pkgload::load_all()`; no
      failures (pre-existing `vdiffr` snapshot tests skip in this
      environment, unrelated to this change).
